### PR TITLE
Correctly handle carriage returns in messages

### DIFF
--- a/aiokatcp/connection.py
+++ b/aiokatcp/connection.py
@@ -38,7 +38,18 @@ from . import core
 
 logger = logging.getLogger(__name__)
 DEFAULT_LIMIT = 16 * 1024**2
-_BLANK_RE = re.compile(br'^[ \t]*\n?$')
+_BLANK_RE = re.compile(br'^[ \t]*[\r\n]?$')
+
+
+class ConvertCRProtocol(asyncio.StreamReaderProtocol):
+    """Protocol that converts incoming carriage returns to newlines.
+
+    This simplifies extracting the data with :class:`asyncio.StreamReader`,
+    whose :meth:`~asyncio.StreamReader.readuntil` method is limited to a single
+    separator.
+    """
+    def data_received(self, data):
+        super().data_received(data.replace(b'\r', b'\n'))
 
 
 async def _discard_to_eol(stream: asyncio.StreamReader) -> None:

--- a/aiokatcp/test/test_core.py
+++ b/aiokatcp/test/test_core.py
@@ -279,6 +279,10 @@ class TestMessage(unittest.TestCase):
         msg = Message.parse(b'?test message \\0\\n\\r\\t\\e\\_binary\n')
         self.assertEqual(msg, Message.request('test', 'message', b'\0\n\r\t\x1b binary'))
 
+    def test_parse_cr(self) -> None:
+        msg = Message.parse(b'?test message withcarriagereturn\r')
+        self.assertEqual(msg, Message.request('test', 'message', b'withcarriagereturn'))
+
     def test_parse_mid(self) -> None:
         msg = Message.parse(b'?test[222] message \\0\\n\\r\\t\\e\\_binary\n')
         self.assertEqual(msg, Message.request('test', 'message', b'\0\n\r\t\x1b binary', mid=222))

--- a/aiokatcp/test/test_core.py
+++ b/aiokatcp/test/test_core.py
@@ -277,17 +277,21 @@ class TestMessage(unittest.TestCase):
 
     def test_parse(self) -> None:
         msg = Message.parse(b'?test message \\0\\n\\r\\t\\e\\_binary\n')
-        self.assertEqual(msg, Message.request('test', 'message', b'\0\n\r\t\x1b binary'))
+        self.assertEqual(msg, Message.request('test', b'message', b'\0\n\r\t\x1b binary'))
 
     def test_parse_cr(self) -> None:
         msg = Message.parse(b'?test message withcarriagereturn\r')
-        self.assertEqual(msg, Message.request('test', 'message', b'withcarriagereturn'))
+        self.assertEqual(msg, Message.request('test', b'message', b'withcarriagereturn'))
+
+    def test_parse_trailing_whitespace(self) -> None:
+        msg = Message.parse(b'?test message  \n')
+        self.assertEqual(msg, Message.request('test', b'message'))
 
     def test_parse_mid(self) -> None:
         msg = Message.parse(b'?test[222] message \\0\\n\\r\\t\\e\\_binary\n')
-        self.assertEqual(msg, Message.request('test', 'message', b'\0\n\r\t\x1b binary', mid=222))
+        self.assertEqual(msg, Message.request('test', b'message', b'\0\n\r\t\x1b binary', mid=222))
         msg = Message.parse(b'?test[1] message\n')
-        self.assertEqual(msg, Message.request('test', 'message', mid=1))
+        self.assertEqual(msg, Message.request('test', b'message', mid=1))
 
     def test_parse_empty(self) -> None:
         self.assertRaises(KatcpSyntaxError, Message.parse, b'')

--- a/aiokatcp/test/test_server.py
+++ b/aiokatcp/test/test_server.py
@@ -332,6 +332,11 @@ class TestDeviceServer(DeviceServerTestMixin, asynctest.TestCase):
         with self.assertRaises(RuntimeError):
             await self.server.start()
 
+    async def test_carriage_return(self) -> None:
+        await self.get_version_info()
+        await self._write(b'?watchdog[2]\r')
+        await self._check_reply([b'!watchdog[2] ok\n'])
+
     async def test_help(self) -> None:
         await self.get_version_info()
         await self._write(b'?help[1]\n')


### PR DESCRIPTION
In the katcp spec, an <eol> is either \r or \n, but only \n was handled.
The Message class is fixed to treat \r and \n interchangeably.

Because the readuntil API in StreamReader is limited to a single
separator, a protocol wrapper is used to convert \r -> \n as data is
buffered. This is a bit dirty, but the alternative would require
reimplementing most of StreamReader.