### PR TITLE
Connection init breaks when connecting via IPv6

### DIFF
--- a/aiokatcp/connection.py
+++ b/aiokatcp/connection.py
@@ -116,7 +116,10 @@ class Connection(object):
         self.owner = owner
         self.reader = reader
         self.writer = writer  # type: Optional[asyncio.StreamWriter]
-        host, port = writer.get_extra_info('peername')
+        if writer.get_extra_info('socket').family == socket.AF_INET6:
+            host, port, _, _ = writer.get_extra_info('peername')
+        else:
+            host, port = writer.get_extra_info('peername')
         self.address = core.Address(ipaddress.ip_address(host), port)
         self._drain_lock = asyncio.Lock(loop=owner.loop)
         self.is_server = is_server


### PR DESCRIPTION
When a client connection uses IPv6 the Connection class init breaks with
'Too many values to unpack'

The reason for that is that writer.get_extra_info('peername') returns 4
values (address, port, flow info, scope id) for AF_INET6 and just 2
for AF_INET.
See https://docs.python.org/3/library/socket.html