### PR TITLE
Connection init breaks when connecting via IPv6

### DIFF
--- a/aiokatcp/connection.py
+++ b/aiokatcp/connection.py
@@ -116,7 +116,7 @@ class Connection(object):
         self.owner = owner
         self.reader = reader
         self.writer = writer  # type: Optional[asyncio.StreamWriter]
-        host, port = writer.get_extra_info('peername')
+        host, port, *_ = writer.get_extra_info('peername')
         self.address = core.Address(ipaddress.ip_address(host), port)
         self._drain_lock = asyncio.Lock(loop=owner.loop)
         self.is_server = is_server


### PR DESCRIPTION
When a client connection uses IPv6 the Connection class init breaks with
'Too many values to unpack'

The reason for that is that writer.get_extra_info('peername') returns 4
values (address, port, flow info, scope id) for AF_INET6 and just 2
for AF_INET.
See https://docs.python.org/3/library/socket.html

I had a test for this but the Travis build slave was not happy making local
 IPv6 connections.