### PR TITLE
Support servers that do not implement message IDs

### DIFF
--- a/aiokatcp/core.py
+++ b/aiokatcp/core.py
@@ -32,8 +32,8 @@ import logging
 import ipaddress
 import numbers
 from typing import (
-    Match, Any, Callable, Union, Type, Iterable, Tuple,
-    Generic, TypeVar, Optional, cast)
+    Match, Any, Callable, Union, Type, Tuple,
+    Generic, TypeVar, Optional)
 # Only used in type comments, so flake8 complains
 from typing import Dict, List   # noqa: F401
 
@@ -258,7 +258,7 @@ def _encode_enum(value: enum.Enum) -> bytes:
 
 
 def _decode_enum(cls: Type[_E], raw: bytes) -> _E:
-    if hasattr(next(iter(cast(Iterable, cls))), 'katcp_value'):
+    if hasattr(next(iter(cls)), 'katcp_value'):
         for member in cls:
             if getattr(member, 'katcp_value') == raw:
                 return member
@@ -278,7 +278,7 @@ def _default_generic(cls: Type[_T]) -> _T:
 
 
 def _default_enum(cls: Type[_E]) -> _E:
-    return next(iter(cast(Iterable, cls)))
+    return next(iter(cls))
 
 
 # mypy doesn't allow an abstract class to be passed to Type[], hence the

--- a/aiokatcp/test/test_client.py
+++ b/aiokatcp/test/test_client.py
@@ -1,4 +1,4 @@
-# Copyright 2017 National Research Foundation (Square Kilometre Array)
+# Copyright 2017, 2019 National Research Foundation (Square Kilometre Array)
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -59,7 +59,8 @@ class DummyClient(Client):
 
 @nottest
 class BaseTestClient(unittest.TestCase):
-    async def make_server(self, loop) -> Tuple[asyncio.AbstractServer, asyncio.Queue]:
+    async def make_server(self, loop: asyncio.AbstractEventLoop) \
+            -> Tuple[asyncio.AbstractServer, asyncio.Queue]:
         """Start a server listening on localhost.
 
         Returns
@@ -96,14 +97,14 @@ class BaseTestClientAsync(BaseTestClient, asynctest.TestCase):
         (reader, writer) = await client_queue.get()
         return client, reader, writer
 
-    async def _check_received(self, pattern: Pattern[bytes]) -> Match:
+    async def check_received(self, pattern: Pattern[bytes]) -> Match:
         line = await self.remote_reader.readline()
         # mypy thinks assertRegex requires a Pattern[str]
         self.assertRegex(line, pattern)    # type: ignore
         # cast keeps mypy happy (it can't tell that it will always match after the assert)
         return cast(Match, pattern.match(line))
 
-    async def _write(self, data: bytes) -> None:
+    async def write(self, data: bytes) -> None:
         self.remote_writer.write(data)
         await self.remote_writer.drain()
 
@@ -113,11 +114,22 @@ class BaseTestClientAsync(BaseTestClient, asynctest.TestCase):
         # Make sure that wait_connected works when already connected
         await self.client.wait_connected()
 
+
+@timelimit
+@istest
+class TestClient(BaseTestClientAsync):
+    @timelimit(1)
+    async def setUp(self) -> None:
+        self.server, self.client_queue = await self.make_server(self.loop)
+        self.client, self.remote_reader, self.remote_writer = \
+            await self.make_client(self.server, self.client_queue)
+        self.addCleanup(self.remote_writer.close)
+
     async def test_request_ok(self) -> None:
         await self.wait_connected()
         future = self.loop.create_task(self.client.request('echo'))
-        await self._check_received(re.compile(br'^\?echo\[1\]\n\Z'))
-        await self._write(b'!echo[1] ok\n')
+        await self.check_received(re.compile(br'^\?echo\[1\]\n\Z'))
+        await self.write(b'!echo[1] ok\n')
         result = await future
         self.assertEqual(result, ([], []))
         # Again, with arguments. This also tests MID incrementing, non-ASCII
@@ -126,58 +138,58 @@ class BaseTestClientAsync(BaseTestClient, asynctest.TestCase):
         arg_esc = b'h\xaf\xce\\0'  # katcp escaping
         arg_esc_re = re.escape(arg_esc)
         future = self.loop.create_task(self.client.request('echo', b'123', arg))
-        await self._check_received(re.compile(br'^\?echo\[2\] 123 ' + arg_esc_re + br'\n\Z'))
-        await self._write(b'!echo[2] ok 123 ' + arg_esc + b'\n')
+        await self.check_received(re.compile(br'^\?echo\[2\] 123 ' + arg_esc_re + br'\n\Z'))
+        await self.write(b'!echo[2] ok 123 ' + arg_esc + b'\n')
         result = await future
         self.assertEqual(result, ([b'123', arg], []))
 
     async def test_request_fail(self) -> None:
         await self.wait_connected()
         future = self.loop.create_task(self.client.request('failme'))
-        await self._check_received(re.compile(br'^\?failme\[1\]\n\Z'))
-        await self._write(b'!failme[1] fail Error\\_message\n')
+        await self.check_received(re.compile(br'^\?failme\[1\]\n\Z'))
+        await self.write(b'!failme[1] fail Error\\_message\n')
         with self.assertRaisesRegex(FailReply, '^Error message$'):
             await future
 
     async def test_request_fail_no_msg(self) -> None:
         await self.wait_connected()
         future = self.loop.create_task(self.client.request('failme'))
-        await self._check_received(re.compile(br'^\?failme\[1\]\n\Z'))
-        await self._write(b'!failme[1] fail\n')
+        await self.check_received(re.compile(br'^\?failme\[1\]\n\Z'))
+        await self.write(b'!failme[1] fail\n')
         with self.assertRaisesRegex(FailReply, '^$'):
             await future
 
     async def test_request_fail_msg_bad_encoding(self) -> None:
         await self.wait_connected()
         future = self.loop.create_task(self.client.request('failme'))
-        await self._check_received(re.compile(br'^\?failme\[1\]\n\Z'))
-        await self._write(b'!failme[1] fail \xaf\n')
+        await self.check_received(re.compile(br'^\?failme\[1\]\n\Z'))
+        await self.write(b'!failme[1] fail \xaf\n')
         with self.assertRaisesRegex(FailReply, '^\uFFFD$'):
             await future
 
     async def test_request_invalid(self) -> None:
         await self.wait_connected()
         future = self.loop.create_task(self.client.request('invalid-request'))
-        await self._check_received(re.compile(br'^\?invalid-request\[1\]\n\Z'))
-        await self._write(b'!invalid-request[1] invalid Unknown\\_request\n')
+        await self.check_received(re.compile(br'^\?invalid-request\[1\]\n\Z'))
+        await self.write(b'!invalid-request[1] invalid Unknown\\_request\n')
         with self.assertRaisesRegex(InvalidReply, '^Unknown request$'):
             await future
 
     async def test_request_no_code(self) -> None:
         await self.wait_connected()
         future = self.loop.create_task(self.client.request('invalid-request'))
-        await self._check_received(re.compile(br'^\?invalid-request\[1\]\n\Z'))
-        await self._write(b'!invalid-request[1]\n')
+        await self.check_received(re.compile(br'^\?invalid-request\[1\]\n\Z'))
+        await self.write(b'!invalid-request[1]\n')
         with self.assertRaisesRegex(InvalidReply, '^$'):
             await future
 
     async def test_request_with_informs(self) -> None:
         await self.wait_connected()
         future = self.loop.create_task(self.client.request('help'))
-        await self._check_received(re.compile(br'^\?help\[1\]\n\Z'))
-        await self._write(b'#help[1] help Show\\_help\n')
-        await self._write(b'#help[1] halt Halt\n')
-        await self._write(b'!help[1] ok 2\n')
+        await self.check_received(re.compile(br'^\?help\[1\]\n\Z'))
+        await self.write(b'#help[1] help Show\\_help\n')
+        await self.write(b'#help[1] halt Halt\n')
+        await self.write(b'!help[1] ok 2\n')
         result = await future
         self.assertEqual(result, ([b'2'], [
             Message.inform('help', b'help', b'Show help', mid=1),
@@ -190,7 +202,7 @@ class BaseTestClientAsync(BaseTestClient, asynctest.TestCase):
         with self.assertLogs(logging.getLogger('aiokatcp.client')) as cm:
             # Put in bad ones before the good one, so that as soon as we've
             # received the good one from the queue we can finish the test.
-            await self._write(b'#exception\n#foo bad notinteger\n#foo \xc3\xa9 123\n')
+            await self.write(b'#exception\n#foo bad notinteger\n#foo \xc3\xa9 123\n')
             inform = await client.foos.get()
         self.assertRegex(cm.output[0], 'I crashed')
         self.assertRegex(cm.output[1], 'error in inform')
@@ -199,7 +211,7 @@ class BaseTestClientAsync(BaseTestClient, asynctest.TestCase):
     async def test_unhandled_inform(self) -> None:
         client = cast(DummyClient, self.client)
         await self.wait_connected()
-        await self._write(b'#unhandled arg\n')
+        await self.write(b'#unhandled arg\n')
         msg = await client.unhandled.get()
         self.assertEqual(msg, Message.inform('unhandled', b'arg'))
 
@@ -207,21 +219,21 @@ class BaseTestClientAsync(BaseTestClient, asynctest.TestCase):
         await self.wait_connected()
         future = self.loop.create_task(self.client.request('echo'))
         with self.assertLogs(logging.getLogger('aiokatcp.client'), logging.DEBUG):
-            await self._write(b'!surprise[3]\n!echo[1] ok\n')
+            await self.write(b'!surprise[3]\n!echo[1] ok\n')
             await future
 
     async def test_receive_request(self) -> None:
         await self.wait_connected()
         future = self.loop.create_task(self.client.request('echo'))
         with self.assertLogs(logging.getLogger('aiokatcp.client')):
-            await self._write(b'?surprise\n!echo[1] ok\n')
+            await self.write(b'?surprise\n!echo[1] ok\n')
             await future
 
     async def test_reply_no_mid(self) -> None:
         await self.wait_connected()
         future = self.loop.create_task(self.client.request('echo'))
         with self.assertLogs(logging.getLogger('aiokatcp.client')):
-            await self._write(b'!surprise ok\n!echo[1] ok\n')
+            await self.write(b'!surprise ok\n!echo[1] ok\n')
             await future
 
     async def test_context_manager(self) -> None:
@@ -242,17 +254,6 @@ class BaseTestClientAsync(BaseTestClient, asynctest.TestCase):
         writer.close()
         await client.wait_closed()
 
-
-@timelimit
-@istest
-class TestClient(BaseTestClientAsync):
-    @timelimit(1)
-    async def setUp(self) -> None:
-        self.server, self.client_queue = await self.make_server(self.loop)
-        self.client, self.remote_reader, self.remote_writer = \
-            await self.make_client(self.server, self.client_queue)
-        self.addCleanup(self.remote_writer.close)
-
     async def test_unparsable_protocol(self) -> None:
         with self.assertLogs(logging.getLogger('aiokatcp.client')) as cm:
             self.remote_writer.write(b'#version-connect katcp-protocol notvalid\n')
@@ -266,13 +267,6 @@ class TestClient(BaseTestClientAsync):
             line = await self.remote_reader.read()
         self.assertEqual(line, b'')
         self.assertRegex(cm.output[0], r'Unknown protocol version 4\.0')
-
-    async def test_bad_flags(self) -> None:
-        with self.assertLogs(logging.getLogger('aiokatcp.client')) as cm:
-            self.remote_writer.write(b'#version-connect katcp-protocol 5.0-M\n')
-            line = await self.remote_reader.read()
-        self.assertEqual(line, b'')
-        self.assertRegex(cm.output[0], r'Message IDs not supported by server')
 
     async def test_no_connection(self) -> None:
         # Open a second client, which will not get the #version-connect
@@ -290,7 +284,7 @@ class TestClient(BaseTestClientAsync):
 
     async def test_disconnected(self) -> None:
         await self.wait_connected()
-        await self._write(b'#disconnect Server\\_exiting\n')
+        await self.write(b'#disconnect Server\\_exiting\n')
         await self.client.wait_disconnected()
         with self.assertRaises(BrokenPipeError):
             await self.client.request('help')
@@ -311,7 +305,7 @@ class TestClient(BaseTestClientAsync):
 
 @timelimit
 @istest
-class TestClientNoReconnect(BaseTestClientAsync):
+class TestClientNoReconnect(TestClient):
     @timelimit(1)
     async def setUp(self) -> None:
         self.server, self.client_queue = await self.make_server(self.loop)
@@ -337,7 +331,7 @@ class TestClientNoReconnect(BaseTestClientAsync):
 
     async def test_disconnected(self) -> None:
         await self.wait_connected()
-        await self._write(b'#disconnect Server\\_exiting\n')
+        await self.write(b'#disconnect Server\\_exiting\n')
         await self.client.wait_disconnected()
         with self.assertRaises(BrokenPipeError):
             await self.client.request('help')
@@ -354,6 +348,27 @@ class TestClientNoReconnect(BaseTestClientAsync):
         writer.close()
         with self.assertRaises(ConnectionAbortedError):
             await client_task
+
+
+@timelimit
+@istest
+class TestClientNoMidSupport(BaseTestClientAsync):
+    @timelimit(1)
+    async def setUp(self) -> None:
+        self.server, self.client_queue = await self.make_server(self.loop)
+        self.client, self.remote_reader, self.remote_writer = \
+            await self.make_client(self.server, self.client_queue)
+        self.addCleanup(self.remote_writer.close)
+
+    async def test_without_mid(self):
+        self.remote_writer.write(b'#version-connect katcp-protocol 5.0-M\n')
+        await self.client.wait_connected()
+        future = self.loop.create_task(self.client.request('echo'))
+        await self.check_received(re.compile(br'^\?echo\n\Z'))
+        await self.write(b'#echo an\\_inform\n')
+        await self.write(b'!echo ok\n')
+        result = await future
+        self.assertEqual(result, ([], [Message.inform('echo', b'an inform')]))
 
 
 @istest

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+.. rubric:: Version 0.4.2
+
+- Make :class:`~.Client` work with servers that don't support message IDs
+
 .. rubric:: Version 0.4.1
 
 - Make async-timeout a requirement so that katcpcmd works

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,9 +17,9 @@ idna==2.7                 # via requests
 katversion==0.9
 mccabe==0.6.1             # via flake8
 mypy-extensions==0.4.1    # via mypy
-mypy==0.641
+mypy==0.660
 pycodestyle==2.4.0        # via flake8
 pyflakes==2.0.0           # via flake8
 requests==2.20.0          # via coveralls
-typed-ast==1.1.0          # via mypy
+typed-ast==1.2.0          # via mypy
 urllib3==1.24             # via requests


### PR DESCRIPTION
When connected to such a server, each request is locked to avoid
confusion about which reply goes with which request. A heuristic is used
to determine whether an inform is an asynchronous inform or is part of a
reply.