### PR TITLE
Fix endless loop of "socket.send() raised except"

### DIFF
--- a/aiokatcp/connection.py
+++ b/aiokatcp/connection.py
@@ -149,6 +149,12 @@ class Connection(object):
         if self.writer is None:
             return     # We previously detected that it was closed
         try:
+            # Normally this would be checked by the internals of
+            # self.writer.drain and bubble out to self.drain, but there is no
+            # guaranteed that self.drain will be called in the near future
+            # (see Github issue #11).
+            if self.writer.transport.is_closing():
+                raise ConnectionResetError('Connection lost')
             raw = b''.join(bytes(msg) for msg in msgs)
             self.writer.write(raw)
             self.logger.debug('Sent message %r', raw)


### PR DESCRIPTION
If a client is receiving async informs (e.g. sensors) and disconnects,
the server won't notice that the underlying transport has closed and
would keep attempting to send informs, with the above message being
logged each time. It seems that asyncio assumes one regularly drains the
writer (and raises the ConnectionResetError from `drain`), but there is
no good place to put that (we don't want to block the server backend if
one client is slow, although that's a whole 'nother kettle of fish).

Fixed by manually checking for a closed stream. One now gets a single
instance of
```
WARNING:aiokatcp.connection:Connection closed before message could be sent: Connection lost [127.0.0.1:54100]
```
which I think might be due to TCP socket limitations, where you can't
tell that a socket has died until you try to write to it.

Closes #11.