### PR TITLE
Add SensorWatcher

### DIFF
--- a/aiokatcp/__init__.py
+++ b/aiokatcp/__init__.py
@@ -36,12 +36,14 @@ else:
     __version__ = _katversion.get_version(__path__[0])   # type: ignore  # mypy issue 1422
 # END VERSION CHECK
 
-from .core import (                                   # noqa: F401
+from .core import (                                              # noqa: F401
     Message, KatcpSyntaxError, Address, Timestamp, TimestampOrNow, Now,
     encode, decode, register_type, get_type, TypeInfo)
 from .connection import Connection, FailReply, InvalidReply      # noqa: F401
 from .server import DeviceServer, RequestContext                 # noqa: F401
-from .client import Client, ProtocolError                        # noqa: F401
+from .client import (                                            # noqa: F401
+    Client, ProtocolError, AbstractSensorWatcher, SensorWatcher,
+    SyncState)
 from .sensor import Reading, Sensor, SensorSampler, SensorSet    # noqa: F401
 
 

--- a/aiokatcp/__init__.py
+++ b/aiokatcp/__init__.py
@@ -40,9 +40,9 @@ from .core import (                                   # noqa: F401
     Message, KatcpSyntaxError, Address, Timestamp, TimestampOrNow, Now,
     encode, decode, register_type, get_type, TypeInfo)
 from .connection import Connection, FailReply, InvalidReply      # noqa: F401
-from .server import DeviceServer, RequestContext, SensorSet      # noqa: F401
-from .client import Client, ProtocolError             # noqa: F401
-from .sensor import Reading, Sensor, SensorSampler    # noqa: F401
+from .server import DeviceServer, RequestContext                 # noqa: F401
+from .client import Client, ProtocolError                        # noqa: F401
+from .sensor import Reading, Sensor, SensorSampler, SensorSet    # noqa: F401
 
 
 def minor_version():

--- a/aiokatcp/client.py
+++ b/aiokatcp/client.py
@@ -790,9 +790,9 @@ class _SensorMonitor:
         except OSError as error:
             # Connection died before we finished. Log it, but no need for
             # a stack trace.
-            self._logger.warning('Connection error in update task: %s', error)
+            self.logger.warning('Connection error in update task: %s', error)
         except Exception:
-            self._logger.exception('Exception in update task')
+            self.logger.exception('Exception in update task')
 
     def _trigger_update(self) -> None:
         self.logger.debug('Sensor sync triggered')

--- a/aiokatcp/client.py
+++ b/aiokatcp/client.py
@@ -682,7 +682,8 @@ class SensorWatcher(AbstractSensorWatcher):
                 # normalising names in some way doesn't guarantee that.
                 # Instead, we use arbitrary numbering.
                 enums = [('ENUM{}'.format(i), value) for i, value in enumerate(values)]
-                stype = enum.Enum('discrete', enums, type=DiscreteMixin)
+                # Type checking disabled due to https://github.com/python/mypy/issues/4184
+                stype = enum.Enum('discrete', enums, type=DiscreteMixin)  # type: ignore
                 self._enum_cache[values] = stype
                 return stype
         else:

--- a/aiokatcp/client.py
+++ b/aiokatcp/client.py
@@ -651,6 +651,13 @@ class SensorWatcher(AbstractSensorWatcher):
         has the same legal values in the same order as the remote sensor. If
         a discrete sensor has no matching enum type, one is synthesized on the
         fly.
+
+    Attributes
+    ----------
+    sensors : :class:`SensorSet`
+        The mirrored sensors
+    synced : :class:`asyncio.Event`
+        Event that is set whenever the state is :const:`SyncState.SYNCED`
     """
 
     SENSOR_TYPES = {
@@ -829,6 +836,7 @@ class _SensorMonitor:
                 self._sampling_set.add(name)
 
     async def _update(self) -> None:
+        """Refresh the sensor list and subscriptions."""
         reply, informs = await self.client.request('sensor-list')
         sampling = []       # type: List[str]
         seen = set()        # type: Set[str]

--- a/aiokatcp/client.py
+++ b/aiokatcp/client.py
@@ -173,7 +173,7 @@ class Client(metaclass=ClientMeta):
             except KeyError:
                 self.logger.debug(
                     'Received %r with unknown message ID %s (possibly cancelled request)',
-                    bytes(msg), msg.mid)    # type: ignore
+                    bytes(msg), msg.mid)
             else:
                 if msg.mtype == core.Message.Type.REPLY:
                     req.reply.set_result(msg)
@@ -191,7 +191,7 @@ class Client(metaclass=ClientMeta):
         self.logger.debug('Received %s', bytes(msg))
         # TODO: provide dispatch mechanism for informs
         handler = self._inform_handlers.get(               # type: ignore
-            msg.name, self.__class__.unhandled_inform)     # type: ignore
+            msg.name, self.__class__.unhandled_inform)
         try:
             handler(self, msg)
         except FailReply as error:

--- a/aiokatcp/client.py
+++ b/aiokatcp/client.py
@@ -580,7 +580,7 @@ class SyncState(enum.Enum):
     #: Not currently connected to the server
     DISCONNECTED = 1
     #: Connected to the server, but still subscribing to sensors
-    UNSYNCED = 2
+    SYNCING = 2
     #: Connected to the server and sensor list is up to date
     SYNCED = 3
     #: Client object has been closed (:meth:`Client.close`)
@@ -817,7 +817,7 @@ class _SensorMonitor:
     def _trigger_update(self) -> None:
         self.logger.debug('Sensor sync triggered')
         for watcher in self._watchers:
-            watcher.state_updated(SyncState.UNSYNCED)
+            watcher.state_updated(SyncState.SYNCING)
         self._cancel_update()
         self._update_task = self.client.loop.create_task(self._update())
         self._update_task.add_done_callback(self._update_done)

--- a/aiokatcp/client.py
+++ b/aiokatcp/client.py
@@ -793,9 +793,9 @@ class _SensorMonitor:
             yield
         finally:
             self.logger.debug('Exiting batch')
-            self._in_batch = False
             for watcher in self._watchers:
                 watcher.batch_stop()
+            self._in_batch = False
 
     def _cancel_update(self) -> None:
         if self._update_task is not None:

--- a/aiokatcp/client.py
+++ b/aiokatcp/client.py
@@ -176,7 +176,8 @@ class Client(metaclass=ClientMeta):
                     bytes(msg), msg.mid)
             else:
                 if msg.mtype == core.Message.Type.REPLY:
-                    req.reply.set_result(msg)
+                    if not req.reply.done():
+                        req.reply.set_result(msg)
                 elif msg.mtype == core.Message.Type.INFORM:
                     req.informs.append(msg)
                 else:
@@ -589,14 +590,14 @@ class AbstractSensorWatcher:
     """
     def sensor_added(self, name: str, description: str, units: str, type_name: str,
                      *args: bytes) -> None:
-        pass
+        pass         # pragma: nocover
 
     def sensor_removed(self, name: str) -> None:
-        pass
+        pass         # pragma: nocover
 
     def sensor_updated(self, name: str, value: bytes,
                        status: sensor.Sensor.Status, timestamp: float) -> None:
-        pass
+        pass         # pragma: nocover
 
     def batch_start(self) -> None:
         """Called at the start of a batch of back-to-back updates.
@@ -604,18 +605,18 @@ class AbstractSensorWatcher:
         Calls to :meth:`sensor_added`, :meth:`sensor_removed` and :meth:`sensor_updated`
         will always be bracketed by :meth:`batch_start` and :meth:`batch_stop`. This
         does not apply to :meth:`state_updated`."""
-        pass
+        pass         # pragma: nocover
 
     def batch_stop(self) -> None:
         """Called at the end of a batch of back-to-back updates."""
-        pass
+        pass         # pragma: nocover
 
     def state_updated(self, state: SyncState) -> None:
         """Indicates the state of the synchronisation state machine.
 
         Implementations should assume the initial state is DISCONNECTED.
         """
-        pass
+        pass         # pragma: nocover
 
 
 class DiscreteMixin:
@@ -766,10 +767,6 @@ class _SensorMonitor:
     def __bool__(self) -> bool:
         """True if there are any watchers"""
         return bool(self._watchers)
-
-    def __len__(self) -> int:
-        """Number of watchers"""
-        return len(self._watchers)
 
     @contextlib.contextmanager
     def _batch(self) -> Generator[None, None, None]:

--- a/aiokatcp/connection.py
+++ b/aiokatcp/connection.py
@@ -308,5 +308,6 @@ def wrap_handler(name: str, handler: Callable, fixed: int) -> Callable:
                           annotation=core.Message))
     wrapper.__signature__ = sig.replace(parameters=wrapper_parameters)  # type: ignore
     wrapper = _identity_decorator(wrapper)
+    wrapper._aiokatcp_orig_handler = handler
 
     return wrapper

--- a/aiokatcp/connection.py
+++ b/aiokatcp/connection.py
@@ -308,6 +308,6 @@ def wrap_handler(name: str, handler: Callable, fixed: int) -> Callable:
                           annotation=core.Message))
     wrapper.__signature__ = sig.replace(parameters=wrapper_parameters)  # type: ignore
     wrapper = _identity_decorator(wrapper)
-    wrapper._aiokatcp_orig_handler = handler
+    wrapper._aiokatcp_orig_handler = handler                            # type: ignore
 
     return wrapper

--- a/aiokatcp/sensor.py
+++ b/aiokatcp/sensor.py
@@ -303,7 +303,7 @@ class SensorSampler(Generic[_T], metaclass=abc.ABCMeta):
         self.observer = None
 
     @abc.abstractmethod
-    def parameters(self) -> Tuple:
+    def parameters(self) -> tuple:
         pass       # pragma: no cover
 
     @classmethod

--- a/aiokatcp/sensor.py
+++ b/aiokatcp/sensor.py
@@ -103,6 +103,10 @@ class Sensor(Generic[_T]):
         UNREACHABLE = 5
         INACTIVE = 6
 
+        def valid_value(self) -> bool:
+            """True if this state is one where the value provided is valid."""
+            return self in {Sensor.Status.NOMINAL, Sensor.Status.WARN, Sensor.Status.ERROR}
+
     def __init__(self, sensor_type: Type[_T],
                  name: str,
                  description: str = None,

--- a/aiokatcp/server.py
+++ b/aiokatcp/server.py
@@ -34,7 +34,7 @@ import io
 import re
 import time
 from typing import (Set, Callable, Awaitable, Sequence, Iterable,
-                    Optional, List, Tuple, Any, TypeVar, cast)
+                    Optional, List, Any, TypeVar, cast)
 # Only used in type comments, so flake8 complains
 from typing import Dict    # noqa: F401
 

--- a/aiokatcp/server.py
+++ b/aiokatcp/server.py
@@ -1,4 +1,4 @@
-# Copyright 2017 National Research Foundation (Square Kilometre Array)
+# Copyright 2017, 2019 National Research Foundation (Square Kilometre Array)
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -30,16 +30,13 @@ import asyncio
 import functools
 import logging
 import traceback
-import enum
 import io
 import re
 import time
-from typing import (
-    Callable, Awaitable, Sequence, Iterable, Mapping,
-    Iterator, Optional, List, Tuple, Any, TypeVar,
-    Union, KeysView, ValuesView, ItemsView, cast, overload)
+from typing import (Set, Callable, Awaitable, Sequence, Iterable,
+                    Optional, List, Tuple, Any, TypeVar, cast)
 # Only used in type comments, so flake8 complains
-from typing import Dict, Set    # noqa: F401
+from typing import Dict    # noqa: F401
 
 import aiokatcp
 from . import core, connection, sensor
@@ -192,125 +189,6 @@ class DeviceServerMeta(type):
         return result
 
 
-class SensorSet(Mapping[str, sensor.Sensor]):
-    """A dict-like and set-like collection of sensors.
-
-    It stores a corresponding list of connections, and removing a sensor from
-    the set clears any samplers on the corresponding connection.
-    """
-
-    class _Sentinel(enum.Enum):
-        """Internal enum used to signal that no default is provided to pop"""
-        NO_DEFAULT = 0
-
-    def __init__(self, connections: Set[ClientConnection]) -> None:
-        self._connections = connections
-        self._sensors = {}       # type: Dict[str, sensor.Sensor]
-
-    def _removed(self, s: sensor.Sensor):
-        """Clear a sensor's samplers from all connections."""
-        for conn in self._connections:
-            conn.set_sampler(s, None)
-
-    def add(self, elem: sensor.Sensor):
-        if elem.name in self._sensors:
-            if self._sensors[elem.name] is not elem:
-                del self[elem.name]
-            else:
-                return
-        self._sensors[elem.name] = elem
-
-    def remove(self, elem: sensor.Sensor) -> None:
-        if elem not in self:
-            raise KeyError(elem.name)
-        del self[elem.name]
-
-    def discard(self, elem: sensor.Sensor) -> None:
-        try:
-            self.remove(elem)
-        except KeyError:
-            pass
-
-    def clear(self) -> None:
-        while self._sensors:
-            self.popitem()
-
-    def popitem(self) -> Tuple[str, sensor.Sensor]:
-        name, value = self._sensors.popitem()
-        self._removed(value)
-        return name, value
-
-    def pop(self, key: str,
-            default: Union[sensor.Sensor, None, _Sentinel] = _Sentinel.NO_DEFAULT) \
-            -> Optional[sensor.Sensor]:
-        if key not in self._sensors:
-            if isinstance(default, self._Sentinel):
-                raise KeyError(key)
-            else:
-                return default
-        else:
-            s = self._sensors.pop(key)
-            self._removed(s)
-            return s
-
-    def __delitem__(self, key: str) -> None:
-        s = self._sensors.pop(key)
-        self._removed(s)
-
-    def __getitem__(self, name: str) -> sensor.Sensor:
-        return self._sensors[name]
-
-    @overload
-    def get(self, name: str) -> Optional[sensor.Sensor]: ...
-
-    @overload     # noqa: F811
-    def get(self, name: str, default: Union[sensor.Sensor, _T]) -> Union[sensor.Sensor, _T]: ...
-
-    def get(self, name: str, default: object = None) -> object:    # noqa: F811
-        return self._sensors.get(name, default)
-
-    def __contains__(self, s: object) -> bool:
-        if isinstance(s, sensor.Sensor):
-            return s.name in self._sensors and self._sensors[s.name] is s
-        else:
-            return s in self._sensors
-
-    def __len__(self) -> int:
-        return len(self._sensors)
-
-    def __bool__(self) -> bool:
-        return bool(self._sensors)
-
-    def __iter__(self) -> Iterator[str]:
-        return iter(self._sensors)
-
-    def keys(self) -> KeysView[str]:
-        return self._sensors.keys()
-
-    def values(self) -> ValuesView[sensor.Sensor]:
-        return self._sensors.values()
-
-    def items(self) -> ItemsView[str, sensor.Sensor]:
-        return self._sensors.items()
-
-    def copy(self) -> Dict[str, sensor.Sensor]:
-        return self._sensors.copy()
-
-    __hash__ = None     # type: ignore     # mypy can't handle this
-
-    add.__doc__ = set.add.__doc__
-    remove.__doc__ = set.remove.__doc__
-    discard.__doc__ = set.discard.__doc__
-    clear.__doc__ = dict.clear.__doc__
-    popitem.__doc__ = dict.popitem.__doc__
-    pop.__doc__ = dict.pop.__doc__
-    get.__doc__ = dict.get.__doc__
-    keys.__doc__ = dict.keys.__doc__
-    values.__doc__ = dict.values.__doc__
-    items.__doc__ = dict.items.__doc__
-    copy.__doc__ = dict.copy.__doc__
-
-
 class DeviceServer(metaclass=DeviceServerMeta):
     """Server that handles katcp.
 
@@ -395,7 +273,14 @@ class DeviceServer(metaclass=DeviceServerMeta):
         self._host = host
         self._port = port
         self._stopping = False
-        self.sensors = SensorSet(self._connections)
+        self.sensors = sensor.SensorSet()
+        self.sensors.add_remove_callback(
+            functools.partial(self._remove_sensor_callback, self._connections))
+
+    @staticmethod
+    def _remove_sensor_callback(connections: Set[ClientConnection], sensor: sensor.Sensor):
+        for conn in connections:
+            conn.set_sampler(sensor, None)
 
     async def start(self) -> None:
         """Start the server running on the event loop.

--- a/aiokatcp/server.py
+++ b/aiokatcp/server.py
@@ -758,7 +758,7 @@ class DeviceServer(metaclass=DeviceServerMeta):
     async def request_sensor_sampling(
             self, ctx: RequestContext, name: str,
             strategy: sensor.SensorSampler.Strategy = None,
-            *args: bytes) -> Tuple:
+            *args: bytes) -> tuple:
         """Configure or query the way a sensor is sampled.
 
         Sampled values are reported asynchronously using the #sensor-status

--- a/aiokatcp/test/test_client.py
+++ b/aiokatcp/test/test_client.py
@@ -352,7 +352,7 @@ class TestSensorMonitor(BaseTestClientAsync):
     async def connect(self) -> None:
         """Get as far as the monitor issuing ``?sensor-list``"""
         await self.wait_connected()
-        self.watcher.state_updated.assert_called_with(SyncState.UNSYNCED)
+        self.watcher.state_updated.assert_called_with(SyncState.SYNCING)
         self.watcher.reset_mock()
         await self.check_received(b'?sensor-list[1]\n')
 
@@ -395,7 +395,7 @@ class TestSensorMonitor(BaseTestClientAsync):
         """Send a ``#interface-changed`` inform and wait for ``?sensor-list``"""
         await self.write(b'#interface-changed sensor-list\n#wakeup\n')
         await self.wakeup()
-        self.watcher.state_updated.assert_called_with(SyncState.UNSYNCED)
+        self.watcher.state_updated.assert_called_with(SyncState.SYNCING)
         self.watcher.reset_mock()
         await self.check_received(b'?sensor-list[3]\n')
 
@@ -466,7 +466,7 @@ class TestSensorMonitor(BaseTestClientAsync):
         await self.write(b'!sensor-list[3] ok 0\n#wakeup\n')
         await self.wakeup()
         self.assertEqual(self.watcher.mock_calls, [
-            call.state_updated(SyncState.UNSYNCED),
+            call.state_updated(SyncState.SYNCING),
             call.batch_start(),
             call.sensor_removed('device-status'),
             call.batch_stop(),
@@ -493,7 +493,7 @@ class TestSensorMonitor(BaseTestClientAsync):
         await self.wakeup()
         self.assertEqual(self.watcher.mock_calls, [
             call.state_updated(SyncState.SYNCED),
-            call.state_updated(SyncState.UNSYNCED),
+            call.state_updated(SyncState.SYNCING),
             call.batch_start(),
             call.sensor_removed('device-status'),
             call.batch_stop(),
@@ -524,7 +524,7 @@ class TestSensorMonitor(BaseTestClientAsync):
         (self.remote_reader, self.remote_writer) = await self.client_queue.get()
 
         await self.wait_connected()
-        self.watcher.state_updated.assert_called_with(SyncState.UNSYNCED)
+        self.watcher.state_updated.assert_called_with(SyncState.SYNCING)
         self.watcher.reset_mock()
         await self.check_received(b'?sensor-list[3]\n')
         await self.write(
@@ -662,7 +662,7 @@ class TestSensorWatcher(asynctest.TestCase):
     def test_state_updated(self):
         self.test_sensor_added()
 
-        self.watcher.state_updated(SyncState.UNSYNCED)
+        self.watcher.state_updated(SyncState.SYNCING)
         self.assertFalse(self.watcher.synced.is_set())
         self.assertEqual(len(self.watcher.sensors), 1)
         self.assertEqual(self.watcher.sensors['test_foo'].status, Sensor.Status.UNKNOWN)

--- a/aiokatcp/test/test_client.py
+++ b/aiokatcp/test/test_client.py
@@ -99,8 +99,7 @@ class BaseTestClientAsync(BaseTestClient, asynctest.TestCase):
 
     async def check_received(self, pattern: Pattern[bytes]) -> Match:
         line = await self.remote_reader.readline()
-        # mypy thinks assertRegex requires a Pattern[str]
-        self.assertRegex(line, pattern)    # type: ignore
+        self.assertRegex(line, pattern)
         # cast keeps mypy happy (it can't tell that it will always match after the assert)
         return cast(Match, pattern.match(line))
 

--- a/aiokatcp/test/test_client.py
+++ b/aiokatcp/test/test_client.py
@@ -219,7 +219,7 @@ class TestClient(BaseTestClientAsync):
         def callback(string: str, integer: int) -> None:
             values.put_nowait((string, integer))
 
-        values = asyncio.Queue(loop=self.loop)
+        values = asyncio.Queue(loop=self.loop)    # type: asyncio.Queue[Tuple[str, int]]
         client = cast(DummyClient, self.client)
         client.add_inform_callback('bar', callback)
         await self.wait_connected()

--- a/aiokatcp/test/test_client.py
+++ b/aiokatcp/test/test_client.py
@@ -502,9 +502,11 @@ class TestSensorMonitor(BaseTestClientAsync):
         self.watcher.reset_mock()
 
     async def test_remove_sensor_watcher(self):
-        # Mostly just a coverage test
+        """Removing the last watcher unsubscribes"""
         await self.test_init()
         self.client.remove_sensor_watcher(self.watcher)
+        await self.check_received(b'?sensor-sampling[3] device-status none\n')
+        await self.write(b'!sensor-sampling[3] ok device-status none\n')
 
     async def test_close(self):
         """Closing the client must update the state"""

--- a/aiokatcp/test/test_sensor.py
+++ b/aiokatcp/test/test_sensor.py
@@ -34,7 +34,7 @@ import unittest
 
 import asynctest
 
-from aiokatcp.sensor import Sensor, SensorSampler
+from aiokatcp.sensor import Sensor, SensorSampler, SensorSet
 
 
 class TestSensor(unittest.TestCase):
@@ -64,3 +64,158 @@ class TestSensorSampling(asynctest.TestCase):
             # Run gc twice because PyPy sometimes needs this.
             gc.collect()
             gc.collect()
+
+
+class TestSensorSet(unittest.TestCase):
+    def setUp(self):
+        self.ss = SensorSet()
+        self.callback = unittest.mock.MagicMock()
+        self.ss.add_remove_callback(self.callback)
+        self.sensors = [Sensor(int, 'name{}'.format(i)) for i in range(5)]
+        # A different set of sensors with the same names
+        self.alt_sensors = [Sensor(float, 'name{}'.format(i)) for i in range(5)]
+        self.ss.add(self.sensors[0])
+
+    def _assert_sensors(self, ss, sensors):
+        """Assert that `ss` has the same sensors as `sensors`"""
+        ordered = sorted(ss.values(), key=lambda x: x.name)
+        self.assertEqual(ordered, sensors)
+
+    def test_construct(self):
+        """Test that setUp put things into the right state."""
+        self._assert_sensors(self.ss, [self.sensors[0]])
+
+    def test_add(self):
+        # Add a new one
+        self.ss.add(self.sensors[1])
+        self._assert_sensors(self.ss, [self.sensors[0], self.sensors[1]])
+        # Add the same one
+        self.ss.add(self.sensors[0])
+        self._assert_sensors(self.ss, [self.sensors[0], self.sensors[1]])
+        # Replace one
+        self.callback.assert_not_called()
+        self.ss.add(self.alt_sensors[1])
+        self._assert_sensors(self.ss, [self.sensors[0], self.alt_sensors[1]])
+        self.callback.assert_called_once_with(self.sensors[1])
+
+    def test_remove(self):
+        # Try to remove non-existent name
+        with self.assertRaises(KeyError):
+            self.ss.remove(self.sensors[4])
+        # Try to remove one with the same name as an existing one
+        with self.assertRaises(KeyError):
+            self.ss.remove(self.alt_sensors[0])
+        self._assert_sensors(self.ss, [self.sensors[0]])
+        # Remove one
+        self.callback.assert_not_called()
+        self.ss.remove(self.sensors[0])
+        self._assert_sensors(self.ss, [])
+        self.callback.assert_called_once_with(self.sensors[0])
+
+    def test_discard(self):
+        # Try to remove non-existent name
+        self.ss.discard(self.sensors[4])
+        # Try to remove one with the same name as an existing one
+        self.ss.discard(self.alt_sensors[0])
+        self._assert_sensors(self.ss, [self.sensors[0]])
+        # Remove one
+        self.callback.assert_not_called()
+        self.ss.discard(self.sensors[0])
+        self._assert_sensors(self.ss, [])
+        self.callback.assert_called_once_with(self.sensors[0])
+
+    def test_clear(self):
+        self.ss.add(self.sensors[1])
+        self.ss.clear()
+        self._assert_sensors(self.ss, [])
+        self.callback.assert_any_call(self.sensors[0])
+        self.callback.assert_any_call(self.sensors[1])
+
+    def test_popitem(self):
+        self.ss.add(self.sensors[1])
+        items = []
+        try:
+            for _ in range(100):   # To prevent infinite loop if it's broken
+                items.append(self.ss.popitem())
+        except KeyError:
+            pass
+        items.sort(key=lambda x: x[0])
+        self.assertEqual(items, [('name0', self.sensors[0]), ('name1', self.sensors[1])])
+        self.callback.assert_any_call(self.sensors[0])
+        self.callback.assert_any_call(self.sensors[1])
+
+    def test_pop_absent(self):
+        # Non-existent name
+        with self.assertRaises(KeyError):
+            self.ss.pop('name4')
+        # Non-existent with defaults
+        self.assertIsNone(self.ss.pop('name4', None))
+        self.assertEqual(self.ss.pop('name4', 'foo'), 'foo')
+        # Remove one
+        self.callback.assert_not_called()
+        self.assertIs(self.ss.pop('name0'), self.sensors[0])
+        self._assert_sensors(self.ss, [])
+        self.callback.assert_called_once_with(self.sensors[0])
+
+    def test_delitem(self):
+        # Try to remove non-existent name
+        with self.assertRaises(KeyError):
+            del self.ss['name4']
+        self._assert_sensors(self.ss, [self.sensors[0]])
+        # Remove one
+        self.callback.assert_not_called()
+        del self.ss['name0']
+        self._assert_sensors(self.ss, [])
+        self.callback.assert_called_once_with(self.sensors[0])
+
+    def test_getitem(self):
+        # Non-existing name
+        with self.assertRaises(KeyError):
+            self.ss['name4']
+        # Existing name
+        self.assertIs(self.ss['name0'], self.sensors[0])
+
+    def test_get(self):
+        # Non-existing name
+        self.assertIsNone(self.ss.get('name4'))
+        self.assertIsNone(self.ss.get('name4', None))
+        self.assertEqual(self.ss.get('name4', 'foo'), 'foo')
+        # Existing name
+        self.assertIs(self.ss.get('name0'), self.sensors[0])
+
+    def test_len(self):
+        self.assertEqual(len(self.ss), 1)
+        self.ss.add(self.sensors[1])
+        self.assertEqual(len(self.ss), 2)
+
+    def test_contains(self):
+        self.assertIn(self.sensors[0], self.ss)
+        self.assertNotIn(self.alt_sensors[0], self.ss)
+        self.assertNotIn(self.sensors[1], self.ss)
+
+    def test_bool(self):
+        self.assertTrue(self.ss)
+        self.ss.clear()
+        self.assertFalse(self.ss)
+
+    def test_keys(self):
+        self.ss.add(self.sensors[1])
+        self.assertEqual(sorted(self.ss.keys()), ['name0', 'name1'])
+
+    def test_values(self):
+        self.ss.add(self.sensors[1])
+        self.assertEqual(sorted(self.ss.values(), key=lambda x: x.name),
+                         [self.sensors[0], self.sensors[1]])
+
+    def test_items(self):
+        self.ss.add(self.sensors[1])
+        self.assertEqual(sorted(self.ss.items()), [
+            ('name0', self.sensors[0]),
+            ('name1', self.sensors[1])
+        ])
+
+    def test_iter(self):
+        self.assertEqual(sorted(iter(self.ss)), ['name0'])
+
+    def test_copy(self):
+        self.assertEqual(self.ss.copy(), {'name0': self.sensors[0]})

--- a/aiokatcp/test/test_sensor.py
+++ b/aiokatcp/test/test_sensor.py
@@ -37,6 +37,18 @@ import asynctest
 from aiokatcp.sensor import Sensor, SensorSampler, SensorSet
 
 
+class TestSensorState(unittest.TestCase):
+    def test_valid_value(self):
+        Status = Sensor.Status
+        self.assertFalse(Status.UNKNOWN.valid_value())
+        self.assertTrue(Status.NOMINAL.valid_value())
+        self.assertTrue(Status.WARN.valid_value())
+        self.assertTrue(Status.ERROR.valid_value())
+        self.assertFalse(Status.FAILURE.valid_value())
+        self.assertFalse(Status.UNREACHABLE.valid_value())
+        self.assertFalse(Status.INACTIVE.valid_value())
+
+
 class TestSensor(unittest.TestCase):
     def test_status_func(self):
         def status_func(value):

--- a/aiokatcp/test/test_server.py
+++ b/aiokatcp/test/test_server.py
@@ -1,4 +1,4 @@
-# Copyright 2017 National Research Foundation (Square Kilometre Array)
+# Copyright 2017, 2019 National Research Foundation (Square Kilometre Array)
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -40,7 +40,7 @@ import asynctest
 import aiokatcp
 from aiokatcp.core import Message, Address
 from aiokatcp.connection import FailReply
-from aiokatcp.server import DeviceServer, RequestContext, SensorSet
+from aiokatcp.server import DeviceServer, RequestContext
 from aiokatcp.sensor import Sensor
 from .test_utils import timelimit
 
@@ -48,161 +48,6 @@ from .test_utils import timelimit
 class Foo(enum.Enum):
     FIRST_VALUE = 1
     SECOND_VALUE = 2
-
-
-class TestSensorSet(unittest.TestCase):
-    def setUp(self):
-        self.conn = unittest.mock.MagicMock()
-        self.connections = set([self.conn])
-        self.ss = SensorSet(self.connections)
-        self.sensors = [Sensor(int, 'name{}'.format(i)) for i in range(5)]
-        # A different set of sensors with the same names
-        self.alt_sensors = [Sensor(float, 'name{}'.format(i)) for i in range(5)]
-        self.ss.add(self.sensors[0])
-
-    def _assert_sensors(self, ss, sensors):
-        """Assert that `ss` has the same sensors as `sensors`"""
-        ordered = sorted(ss.values(), key=lambda x: x.name)
-        self.assertEqual(ordered, sensors)
-
-    def test_construct(self):
-        """Test that setUp put things into the right state."""
-        self._assert_sensors(self.ss, [self.sensors[0]])
-
-    def test_add(self):
-        # Add a new one
-        self.ss.add(self.sensors[1])
-        self._assert_sensors(self.ss, [self.sensors[0], self.sensors[1]])
-        # Add the same one
-        self.ss.add(self.sensors[0])
-        self._assert_sensors(self.ss, [self.sensors[0], self.sensors[1]])
-        # Replace one
-        self.conn.set_sampler.assert_not_called()
-        self.ss.add(self.alt_sensors[1])
-        self._assert_sensors(self.ss, [self.sensors[0], self.alt_sensors[1]])
-        self.conn.set_sampler.assert_called_once_with(self.sensors[1], None)
-
-    def test_remove(self):
-        # Try to remove non-existent name
-        with self.assertRaises(KeyError):
-            self.ss.remove(self.sensors[4])
-        # Try to remove one with the same name as an existing one
-        with self.assertRaises(KeyError):
-            self.ss.remove(self.alt_sensors[0])
-        self._assert_sensors(self.ss, [self.sensors[0]])
-        # Remove one
-        self.conn.set_sampler.assert_not_called()
-        self.ss.remove(self.sensors[0])
-        self._assert_sensors(self.ss, [])
-        self.conn.set_sampler.assert_called_once_with(self.sensors[0], None)
-
-    def test_discard(self):
-        # Try to remove non-existent name
-        self.ss.discard(self.sensors[4])
-        # Try to remove one with the same name as an existing one
-        self.ss.discard(self.alt_sensors[0])
-        self._assert_sensors(self.ss, [self.sensors[0]])
-        # Remove one
-        self.conn.set_sampler.assert_not_called()
-        self.ss.discard(self.sensors[0])
-        self._assert_sensors(self.ss, [])
-        self.conn.set_sampler.assert_called_once_with(self.sensors[0], None)
-
-    def test_clear(self):
-        self.ss.add(self.sensors[1])
-        self.ss.clear()
-        self._assert_sensors(self.ss, [])
-        self.conn.set_sampler.assert_any_call(self.sensors[0], None)
-        self.conn.set_sampler.assert_any_call(self.sensors[1], None)
-
-    def test_popitem(self):
-        self.ss.add(self.sensors[1])
-        items = []
-        try:
-            for _ in range(100):   # To prevent infinite loop if it's broken
-                items.append(self.ss.popitem())
-        except KeyError:
-            pass
-        items.sort(key=lambda x: x[0])
-        self.assertEqual(items, [('name0', self.sensors[0]), ('name1', self.sensors[1])])
-        self.conn.set_sampler.assert_any_call(self.sensors[0], None)
-        self.conn.set_sampler.assert_any_call(self.sensors[1], None)
-
-    def test_pop_absent(self):
-        # Non-existent name
-        with self.assertRaises(KeyError):
-            self.ss.pop('name4')
-        # Non-existent with defaults
-        self.assertIsNone(self.ss.pop('name4', None))
-        self.assertEqual(self.ss.pop('name4', 'foo'), 'foo')
-        # Remove one
-        self.conn.set_sampler.assert_not_called()
-        self.assertIs(self.ss.pop('name0'), self.sensors[0])
-        self._assert_sensors(self.ss, [])
-        self.conn.set_sampler.assert_called_once_with(self.sensors[0], None)
-
-    def test_delitem(self):
-        # Try to remove non-existent name
-        with self.assertRaises(KeyError):
-            del self.ss['name4']
-        self._assert_sensors(self.ss, [self.sensors[0]])
-        # Remove one
-        self.conn.set_sampler.assert_not_called()
-        del self.ss['name0']
-        self._assert_sensors(self.ss, [])
-        self.conn.set_sampler.assert_called_once_with(self.sensors[0], None)
-
-    def test_getitem(self):
-        # Non-existing name
-        with self.assertRaises(KeyError):
-            self.ss['name4']
-        # Existing name
-        self.assertIs(self.ss['name0'], self.sensors[0])
-
-    def test_get(self):
-        # Non-existing name
-        self.assertIsNone(self.ss.get('name4'))
-        self.assertIsNone(self.ss.get('name4', None))
-        self.assertEqual(self.ss.get('name4', 'foo'), 'foo')
-        # Existing name
-        self.assertIs(self.ss.get('name0'), self.sensors[0])
-
-    def test_len(self):
-        self.assertEqual(len(self.ss), 1)
-        self.ss.add(self.sensors[1])
-        self.assertEqual(len(self.ss), 2)
-
-    def test_contains(self):
-        self.assertIn(self.sensors[0], self.ss)
-        self.assertNotIn(self.alt_sensors[0], self.ss)
-        self.assertNotIn(self.sensors[1], self.ss)
-
-    def test_bool(self):
-        self.assertTrue(self.ss)
-        self.ss.clear()
-        self.assertFalse(self.ss)
-
-    def test_keys(self):
-        self.ss.add(self.sensors[1])
-        self.assertEqual(sorted(self.ss.keys()), ['name0', 'name1'])
-
-    def test_values(self):
-        self.ss.add(self.sensors[1])
-        self.assertEqual(sorted(self.ss.values(), key=lambda x: x.name),
-                         [self.sensors[0], self.sensors[1]])
-
-    def test_items(self):
-        self.ss.add(self.sensors[1])
-        self.assertEqual(sorted(self.ss.items()), [
-            ('name0', self.sensors[0]),
-            ('name1', self.sensors[1])
-        ])
-
-    def test_iter(self):
-        self.assertEqual(sorted(iter(self.ss)), ['name0'])
-
-    def test_copy(self):
-        self.assertEqual(self.ss.copy(), {'name0': self.sensors[0]})
 
 
 class DummyServer(DeviceServer):

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -6,7 +6,8 @@ Changelog
 - Make :class:`~.SensorSet` more generic and move into :mod:`aiokatcp.sensor`
   package. It no longer takes a list of connections; instead, one may register
   callbacks to get notification of removals.
-- Add :meth:`aiokatcp.sensor.Sensor.Status.valid_value`
+- Add :meth:`.Sensor.Status.valid_value`.
+- Add :meth:`.Client.add_inform_callback` and :meth:`.Client.remove_inform_callback`.
 
 .. rubric:: Version 0.4.4
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 - Make :class:`~.SensorSet` more generic and move into :mod:`aiokatcp.sensor`
   package. It no longer takes a list of connections; instead, one may register
   callbacks to get notification of removals.
+- Add :meth:`aiokatcp.sensor.Sensor.Status.valid_value`
 
 .. rubric:: Version 0.4.4
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+.. rubric:: Development version
+
+- Make :class:`~.SensorSet` more generic and move into :mod:`aiokatcp.sensor`
+  package. It no longer takes a list of connections; instead, one may register
+  callbacks to get notification of removals.
+
 .. rubric:: Version 0.4.4
 
 - Support Python 3.7

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -5,9 +5,11 @@ Changelog
 
 - Make :class:`~.SensorSet` more generic and move into :mod:`aiokatcp.sensor`
   package. It no longer takes a list of connections; instead, one may register
-  callbacks to get notification of removals.
+  callbacks to get notification of removals. Note that the constructor
+  interface has changed in a non-compatible way.
 - Add :meth:`.Sensor.Status.valid_value`.
 - Add :meth:`.Client.add_inform_callback` and :meth:`.Client.remove_inform_callback`.
+- Add support for :ref:`sensor_watcher`.
 
 .. rubric:: Version 0.4.4
 

--- a/doc/client.rst
+++ b/doc/client.rst
@@ -7,3 +7,4 @@ Writing a client
 
    client/tutorial
    client/reconnect
+   client/sensor_watcher

--- a/doc/client/sensor_watcher.rst
+++ b/doc/client/sensor_watcher.rst
@@ -4,8 +4,8 @@ Watching sensors
 ----------------
 While the low-level interface can be used to subscribe to updates of specific
 sensors, it is non-trivial to monitor all sensors of a specific remote server
-and react appropriate to changes in the sensor list, disconnections,
-reconnections and so on.  Use cases include proxying a sensor (and hence
+and react appropriately to changes in the sensor list, disconnections,
+reconnections and so on.  Use cases include proxying a remote server (and hence
 mirroring its sensors) and pushing sensor values into another monitoring
 system.
 
@@ -19,7 +19,7 @@ This is a low-level base class which should be subclassed to implement callbacks
 :class:`~.SensorWatcher` is a concrete implementation that processes the
 callbacks into a stored :class:`~.SensorSet` with the mirrored sensors. It can
 also (via subclassing and overriding :meth:`~.SensorWatcher.rewrite_name`)
-modify the names of the mirror sensors as they are created, which may be useful
+modify the names of the mirrored sensors as they are created, which may be useful
 for proxying.
 
 Sensor monitoring operates on a state machine, and state changes are reported

--- a/doc/client/sensor_watcher.rst
+++ b/doc/client/sensor_watcher.rst
@@ -1,0 +1,34 @@
+.. _sensor_watcher:
+
+Watching sensors
+----------------
+While the low-level interface can be used to subscribe to updates of specific
+sensors, it is non-trivial to monitor all sensors of a specific remote server
+and react appropriate to changes in the sensor list, disconnections,
+reconnections and so on.  Use cases include proxying a sensor (and hence
+mirroring its sensors) and pushing sensor values into another monitoring
+system.
+
+To facilitate these use cases, it is possible to add one or more sensor
+watchers to a client, using :meth:`~.Client.add_sensor_watcher`.
+Whenever a client has at least one sensor watcher, it will automatically stay
+subscribed to all sensors.
+
+The sensor watcher must be an instance of :class:`~.AbstractSensorWatcher`.
+This is a low-level base class which should be subclassed to implement callbacks.
+:class:`~.SensorWatcher` is a concrete implementation that processes the
+callbacks into a stored :class:`~.SensorSet` with the mirrored sensors. It can
+also (via subclassing and overriding :meth:`~.SensorWatcher.rewrite_name`)
+modify the names of the mirror sensors as they are created, which may be useful
+for proxying.
+
+Sensor monitoring operates on a state machine, and state changes are reported
+via the :meth:`~.AbstractSensorWatcher.state_updated` callback, which takes a
+:class:`~.SyncState`.
+
+One can also use :attr:`~.SensorWatcher.synced` (an :class:`asyncio.Event`) to
+determine the sync status and to wait for sync to be achieved.
+
+There is an example of using a :class:`~.SensorWatcher` to proxy the sensors of
+one another in :file:`examples/mirror_sensors.py` in the aiokatcp source
+distribution.

--- a/doc/client/tutorial.rst
+++ b/doc/client/tutorial.rst
@@ -60,8 +60,8 @@ values into text.
 
 Asynchronous informs
 --------------------
-To handle asynchronous informs, it is necessary to subclass :class:`~.Client` and
-implement inform handlers. An inform handler is a message named
+There are two ways to handle asynchronous informs. The first is to subclass
+:class:`~.Client` and implement inform handlers. An inform handler is a message named
 :samp:`inform_{name}` where *name* is the name of the inform. The type
 annotations on the arguments are used to convert the arguments from raw bytes
 to those types. For more details, see :ref:`type-conversions`.
@@ -78,7 +78,7 @@ As an example, here is how one might handle ``#sensor-status`` informs:
 
     class MyClient(aiokatcp.Client):
         def inform_sensor_status(self, timestamp: aiokatcp.Timestamp,
-                                   num_sensors: int, *args) -> None:
+                                 num_sensors: int, *args) -> None:
             if len(args) != 3 * num_sensors:
                 raise FailReply('Wrong number of arguments')
             ...
@@ -88,3 +88,9 @@ informs for which there is no specific handler.
 
 Note that the base class already contains inform handlers for a number of
 standard informs.
+
+The second way to deal with asynchronous informs is to register callbacks. This
+has the advantage that it does not require subclassing and so can be used on an
+already-constructed :class:`~.Client`. Instead of a method inside the class,
+write a function (with type annotations on the arguments, as before) and pass
+it to :meth:`.Client.add_inform_callback`.

--- a/doc/migration.rst
+++ b/doc/migration.rst
@@ -63,6 +63,6 @@ General
   :meth:`AbstractEventLoop.call_soon_threadsafe`) to ensure that aiokatcp
   structures are touched only by the thread running the event loop.
 - None of the functions have timeout parameters. Instead, you can cancel
-  coroutines, for example, using `asyncio_timeout`_.
+  coroutines, for example, using `async_timeout`_.
 
-.. _asyncio_timeout: https://github.com/aio-libs/async-timeout
+.. _async_timeout: https://github.com/aio-libs/async-timeout

--- a/examples/mirror_sensors.py
+++ b/examples/mirror_sensors.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 National Research Foundation (Square Kilometre Array)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import asyncio
+import logging
+import signal
+
+import aiokatcp
+
+
+class MirrorServer(aiokatcp.DeviceServer):
+    VERSION = 'mirror-1.0'
+    BUILD_STATE = 'mirror-1.0.0'
+
+
+class MirrorWatcher(aiokatcp.SensorWatcher):
+    def __init__(self, client: aiokatcp.Client, server: aiokatcp.DeviceServer):
+        super().__init__(client)
+        self.server = server
+        self._interface_stale = False
+
+    def sensor_added(self, name: str, description: str, units: str, type_name: str,
+                     *args: bytes) -> None:
+        super().sensor_added(name, description, units, type_name, *args)
+        self.server.sensors.add(self.sensors[name])
+        self._interface_stale = True
+        logging.info('Added sensor %s', name)
+
+    def sensor_removed(self, name: str) -> None:
+        del self.server.sensors[name]
+        self._interface_stale = True
+        super().sensor_removed(name)
+        logging.info('Removed sensor %s', name)
+
+    def batch_stop(self) -> None:
+        if self._interface_stale:
+            self.server.mass_inform('interface-changed', 'sensor-list')
+            self._interface_stale = False
+            logging.info('Sent interface-changed')
+
+
+async def main(args: argparse.Namespace):
+    client = aiokatcp.Client(args.host, args.port)
+    server = MirrorServer('127.0.0.1', args.local_port)
+    await server.start()
+
+    watcher = MirrorWatcher(client, server)
+    client.add_sensor_watcher(watcher)
+
+    asyncio.get_event_loop().add_signal_handler(signal.SIGINT, server.halt)
+    await server.join()
+    client.close()
+    await client.wait_closed()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Mirror another server's sensors")
+    parser.add_argument('host')
+    parser.add_argument('port', type=int)
+    parser.add_argument('local_port', type=int)
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main(args))
+    loop.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,9 +17,9 @@ idna==2.7                 # via requests
 katversion==0.9
 mccabe==0.6.1             # via flake8
 mypy-extensions==0.4.1    # via mypy
-mypy==0.660
+mypy==0.670
 pycodestyle==2.4.0        # via flake8
 pyflakes==2.0.0           # via flake8
 requests==2.20.0          # via coveralls
-typed-ast==1.2.0          # via mypy
+typed-ast==1.3.5          # via mypy
 urllib3==1.24.2           # via requests


### PR DESCRIPTION
The main goal is to provide functionality along the lines of katcp's InspectingClient (but just for sensors so far, not requests). Rather than a new class, I went with an observer pattern, allowing multiple bits of code to each attach a SensorWatcher to an existing client.

There are a few other new features which I added in preparation for this. Rather than explaining it all here, I'd suggest starting the review with the updates to documentation and only then looking at the code.