### PR TITLE
Disconnect clients that don't keep up with asynchronous informs

### DIFF
--- a/aiokatcp/server.py
+++ b/aiokatcp/server.py
@@ -521,6 +521,7 @@ class DeviceServer(metaclass=DeviceServerMeta):
             Fields for the inform
         """
         msg = core.Message.inform(name, *args)
+        # Copy the connection list, because _write_async_message can mutate it.
         for conn in list(self._connections):
             self._write_async_message(conn, msg)
 

--- a/aiokatcp/test/test_server.py
+++ b/aiokatcp/test/test_server.py
@@ -426,6 +426,16 @@ class TestDeviceServer(DeviceServerTestMixin, asynctest.TestCase):
         await self.server.stop()
         self.assertEqual(self.server.on_stop_called, 1)
 
+    async def test_slow_client(self) -> None:
+        self.server.max_backlog = 32768
+        # We need to be sure to push in lots of data, because some of it will
+        # be absorbed by TCP socket buffers, receive buffers etc.
+        big_str = b'x' * 200000
+        self.assertEqual(len(self.server._connections), 1)
+        for i in range(100):
+            self.server.mass_inform('big', big_str)
+        self.assertEqual(len(self.server._connections), 0)
+
 
 class TestDeviceServerClocked(DeviceServerTestMixin, asynctest.ClockedTestCase):
     """Tests for :class:`.DeviceServer` that use a fake clock.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 .. rubric:: Development version
 
 - Add `auto_strategy` parameter to :class:`.Sensor` constructor.
+- Disconnect clients that aren't keeping up with their asynchronous informs.
 
 .. rubric:: Version 0.6.1
 


### PR DESCRIPTION
For now don't worry about synchronous replies, since that's regulated by
the limit on the number of in-flight requests (although a client that
makes many pipelined requests and then doesn't wait for the replies
could in theory be a problem). The main goal is to deal with clients
that aren't keeping up with the updates for sensors they've subscribed
to.