### PR TITLE
Use {!r} to format bytes

### DIFF
--- a/aiokatcp/core.py
+++ b/aiokatcp/core.py
@@ -379,10 +379,10 @@ def decode(cls: Any, value: bytes) -> Any:
         if len(values) == 1:
             return values[0]
         elif not values:
-            raise ValueError('None of the types in {} could decode {}'.format(
+            raise ValueError('None of the types in {} could decode {!r}'.format(
                 cls, value))
         else:
-            raise ValueError('{} is ambiguous for {}'.format(value, cls))
+            raise ValueError('{!r} is ambiguous for {}'.format(value, cls))
     else:
         return get_type(cls).decode(cls, value)
 

--- a/aiokatcp/test/test_core.py
+++ b/aiokatcp/test/test_core.py
@@ -165,7 +165,7 @@ class TestEncodeDecode(unittest.TestCase):
     def test_bad_raw(self) -> None:
         for type_, value in self.BAD_VALUES:
             with self.assertRaises(ValueError,
-                                   msg='{} should not be valid for {}'.format(value, type_)):
+                                   msg='{!r} should not be valid for {}'.format(value, type_)):
                 decode(type_, value)
 
     @unittest.mock.patch('aiokatcp.core._types', [])   # type: ignore


### PR DESCRIPTION
The latest mypy complains if one uses just `{}`.