### PR TITLE
Update link to katcp spec in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ asyncio system module. It requires Python 3.5 or later, as it makes extensive
 uses of coroutines and type annotations. It is loosely inspired by the `Python
 2 bindings`_, but has a much narrower scope.
 
-.. _katcp: https://katcp-python.readthedocs.io/en/latest/_downloads/NRF-KAT7-6.0-IFCE-002-Rev5.pdf
+.. _katcp: https://katcp-python.readthedocs.io/en/latest/_downloads/361189acb383a294be20d6c10c257cb4/NRF-KAT7-6.0-IFCE-002-Rev5-1.pdf
 
 .. _Python 2 bindings: https://github.com/ska-sa/katcp-python
 


### PR DESCRIPTION
It had previously been updated in doc/intro.rst, but was missed in the
README.