### PR TITLE
Bump urllib3 and friends to the latest versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ async-timeout==3.0.1
     # via -r requirements.in
 attrs==19.3.0
     # via pytest
-certifi==2019.11.28
+certifi==2021.5.30
     # via requests
 chardet==3.0.4
     # via requests
@@ -64,7 +64,7 @@ pytest==6.0.1
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-mock
-requests==2.22.0
+requests==2.25.1
     # via coveralls
 six==1.15.0
     # via packaging
@@ -74,5 +74,5 @@ typed-ast==1.4.0
     # via mypy
 typing-extensions==3.7.4.1
     # via mypy
-urllib3==1.25.8
+urllib3==1.26.5
     # via requests


### PR DESCRIPTION
Dependabot was complaining. It's not a real issue since it's only pulled
in by the coveralls package.