### PR TITLE
Make preparations for a 1.0 release

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,3 +1,2 @@
-sphinx-autodoc-typehints==1.6.0
-sphinx==2.1.0
+sphinx==4.1.1
 -r requirements.txt

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+.. rubric:: Version 1.0.0
+
+- Drop support for Python 3.5, and test on versions up to 3.9.
+- Remove explicit ``loop`` arguments.
+- Fix a race condition that could cause lost connections to be logged twice.
+- Switch testing from nosetests to pytest.
+- Switch CI from Travis CI to Github Actions.
+- Use a :file:`pyproject.toml` to specify build-time dependencies.
+- Upgrade Sphinx used for readthedocs to the latest version.
+
 .. rubric:: Version 0.8.0
 
 - Add :meth:`.SensorSet.add_add_callback`, :meth:`SensorSet.remove_add_callback` and

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,7 +34,6 @@ import aiokatcp
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
-    'sphinx_autodoc_typehints',
     'sphinx.ext.mathjax',
     'sphinx.ext.todo']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "katversion"]

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,3 @@
-katversion
 async-solipsism
 async-timeout
 coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,8 +30,6 @@ idna==3.2
     # via requests
 iniconfig==1.1.1
     # via pytest
-katversion==1.1
-    # via -r requirements.in
 mccabe==0.6.1
     # via flake8
 mypy==0.910

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     platforms=['OS Independent'],
     keywords='asyncio katcp',
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Framework :: AsyncIO',
         'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
- Upgrade Sphinx to a new version with builtin support for type hints,
  eliminating sphinx-autodoc-typehints.
- Add a pyproject.toml.
- Write a changelog.
- Change classifier from Beta to Production.