### PR TITLE
Simplify access to a server's sockets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         include:
-          - python-version: "3.9"
+          - python-version: "3.10"
             coverage: "yes"
     steps:
       - uses: actions/checkout@v2

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+.. rubric:: Development version
+
+- Change type annotation of :attr:`.Server.server` from
+  :class:`asyncio.AbstractServer` to the more specific
+  :class:`asyncio.Server`.
+- Add :attr:`.Server.sockets` to simplify querying the sockets of a server.
+
 .. rubric:: Version 1.0.0
 
 - Drop support for Python 3.5, and test on versions up to 3.9.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,4 @@
 [mypy]
-python_version = 3.6
+python_version = 3.7
 ignore_missing_imports = True
 files = src/aiokatcp, examples, tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ iniconfig==1.1.1
     # via pytest
 mccabe==0.6.1
     # via flake8
-mypy==0.910
+mypy==0.942
     # via -r requirements.in
 mypy-extensions==0.4.3
     # via mypy
@@ -64,9 +64,10 @@ requests==2.26.0
     # via coveralls
 toml==0.10.2
     # via
-    #   mypy
     #   pytest
     #   pytest-cov
+tomli==2.0.1
+    # via mypy
 types-decorator==0.1.5
     # via -r requirements.in
 typing-extensions==3.10.0.0

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,6 @@ setup(
             'katcpcmd = aiokatcp.tools.katcpcmd:main'
         ]
     },
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     zip_safe=False   # For py.typed
 )

--- a/src/aiokatcp/core.py
+++ b/src/aiokatcp/core.py
@@ -258,7 +258,8 @@ def _encode_enum(value: enum.Enum) -> bytes:
 
 
 def _decode_enum(cls: Type[_E], raw: bytes) -> _E:
-    if hasattr(next(iter(cls)), 'katcp_value'):
+    # ignore to work around https://github.com/python/mypy/issues/12553
+    if hasattr(next(iter(cls)), 'katcp_value'):  # type: ignore
         for member in cls:
             if getattr(member, 'katcp_value') == raw:
                 return member
@@ -278,7 +279,8 @@ def _default_generic(cls: Type[_T]) -> _T:
 
 
 def _default_enum(cls: Type[_E]) -> _E:
-    return next(iter(cls))
+    # ignore to work around https://github.com/python/mypy/issues/12553
+    return next(iter(cls))  # type: ignore
 
 
 # mypy doesn't allow an abstract class to be passed to Type[], hence the

--- a/src/aiokatcp/server.py
+++ b/src/aiokatcp/server.py
@@ -382,6 +382,20 @@ class DeviceServer(metaclass=DeviceServerMeta):
         """Return the underlying TCP server"""
         return self._server
 
+    @property
+    def sockets(self) -> Tuple[socket.socket, ...]:
+        """Sockets associated with the underlying server.
+
+        If :meth:`start` has not yet been called, this will be empty.
+        """
+        if self._server is None:
+            return ()
+        sockets = self._server.sockets
+        if isinstance(sockets, tuple):  # Python 3.8+
+            return sockets
+        else:
+            return tuple(sockets)
+
     def send_version_info(self, ctx: RequestContext, *, send_reply=True) -> None:
         """Send version information informs to the client.
 

--- a/src/aiokatcp/server.py
+++ b/src/aiokatcp/server.py
@@ -26,15 +26,16 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import inspect
-import asyncio
+import asyncio.base_events
 import functools
 import logging
+import socket
 import traceback
 import io
 import re
 import time
 from typing import (Set, Callable, Awaitable, Sequence, Iterable,
-                    Optional, List, Any, TypeVar, cast)
+                    Optional, List, Tuple, Any, TypeVar, cast)
 # Only used in type comments, so flake8 complains
 from typing import Dict    # noqa: F401
 
@@ -279,7 +280,7 @@ class DeviceServer(metaclass=DeviceServerMeta):
         self._limit = limit
         self.max_backlog = 2 * limit if max_backlog is None else max_backlog
         self._log_level = core.LogLevel.WARN
-        self._server = None        # type: Optional[asyncio.events.AbstractServer]
+        self._server = None        # type: Optional[asyncio.base_events.Server]
         self._server_lock = asyncio.Lock()
         self._stopped = asyncio.Event()
         self._host = host
@@ -377,7 +378,7 @@ class DeviceServer(metaclass=DeviceServerMeta):
         await self._stopped.wait()
 
     @property
-    def server(self) -> Optional[asyncio.AbstractServer]:
+    def server(self) -> Optional[asyncio.base_events.Server]:
         """Return the underlying TCP server"""
         return self._server
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -25,7 +25,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import asyncio
+import asyncio.base_events
 import re
 import logging
 import gc
@@ -79,7 +79,7 @@ def client_queue() -> _ClientQueue:
 
 
 @pytest.fixture
-async def server(client_queue) -> AsyncGenerator[asyncio.AbstractServer, None]:
+async def server(client_queue) -> AsyncGenerator[asyncio.base_events.Server, None]:
     """Start a server listening on [::1]:7777."""
     def callback(reader, writer):
         client_queue.put_nowait((reader, writer))
@@ -123,12 +123,12 @@ class Channel:
     @classmethod
     async def create(
             cls,
-            server: asyncio.AbstractServer,
+            server: asyncio.base_events.Server,
             client_queue: _ClientQueue,
             client_cls: Type[Client] = DummyClient,
             auto_reconnect=True) \
             -> 'Channel':
-        host, port = server.sockets[0].getsockname()[:2]    # type: ignore
+        host, port = server.sockets[0].getsockname()[:2]
         client = client_cls(host, port, auto_reconnect=auto_reconnect)
         (reader, writer) = await client_queue.get()
         return cls(client, reader, writer)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -96,7 +96,7 @@ class TestReadMessage:
 @pytest.fixture
 def owner(event_loop):
     owner = mock.MagicMock()
-    owner.loop = asyncio.get_event_loop()
+    owner.loop = event_loop
     owner.handle_message = mock.MagicMock(side_effect=_ok_handler)
     return owner
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -148,9 +148,9 @@ async def server(request) -> AsyncGenerator[DummyServer, None]:
 
 
 @pytest.fixture
-async def reader_writer_factory(server) \
+async def reader_writer_factory(server: DummyServer) \
         -> AsyncGenerator[Callable[[], Awaitable[_StreamPair]], None]:
-    host, port = server.server.sockets[0].getsockname()[:2]
+    host, port = server.sockets[0].getsockname()[:2]
     writers = []
 
     async def factory() -> _StreamPair:
@@ -216,6 +216,11 @@ async def test_start_twice(server: DummyServer) -> None:
     """Calling start twice raises :exc:`RuntimeError`"""
     with pytest.raises(RuntimeError):
         await server.start()
+
+
+async def test_sockets_not_started() -> None:
+    """An unstarted server must return an empty socket tuple."""
+    assert DummyServer().sockets == ()
 
 
 async def test_carriage_return(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:


### PR DESCRIPTION
Previously you had to write code something like this to keep mypy happy:
```python
assert isinstance(server.server, asyncio.base_events.Server)
sockets = server.server.sockets
```
The type annotation is tightened up so that you can now do
```python
assert server.server is not None
sockets = server.server.sockets
```
and a new attribute is added so that it can be simplified further to
```python
sockets = server.sockets`
```

To keep things simple I made Python 3.7 the minimum version, also had to upgrade mypy. While I was at it I added Python 3.10 to the test matrix, which exposed a test bug.