### PR TITLE
Remove setting of TCP_NODELAY

### DIFF
--- a/src/aiokatcp/connection.py
+++ b/src/aiokatcp/connection.py
@@ -29,7 +29,6 @@ import logging
 import asyncio
 import re
 import ipaddress
-import socket
 import time
 import inspect
 import functools

--- a/src/aiokatcp/connection.py
+++ b/src/aiokatcp/connection.py
@@ -120,9 +120,6 @@ class Connection:
     def __init__(self, owner: Any,
                  reader: asyncio.StreamReader, writer: asyncio.StreamWriter,
                  is_server: bool) -> None:
-        # Set TCP_NODELAY to avoid unnecessary transmission delays. This is
-        # on by default in asyncio from Python 3.6, but not in 3.5.
-        writer.get_extra_info('socket').setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         self.owner = owner
         self.reader = reader
         self.writer = writer  # type: Optional[asyncio.StreamWriter]


### PR DESCRIPTION
It was made the default in Python 3.6, so it is no longer necessary to
do manually.
