### PR TITLE
Add server support for bulk sensor sampling

### DIFF
--- a/src/aiokatcp/server.py
+++ b/src/aiokatcp/server.py
@@ -879,10 +879,7 @@ class DeviceServer(metaclass=DeviceServerMeta):
                     sampler.close()
             # Now create them for real
             for s in sensors:
-                try:
-                    sampler = sensor.SensorSampler.factory(s, observer, self.loop, strategy, *args)
-                except (TypeError, ValueError) as error:
-                    raise FailReply(str(error)) from error
+                sampler = sensor.SensorSampler.factory(s, observer, self.loop, strategy, *args)
                 ctx.conn.set_sampler(s, sampler)
         if sampler is not None:
             params = sampler.parameters()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -105,7 +105,7 @@ class Channel:
         self.writer = writer
 
     async def wait_connected(self) -> None:
-        self.writer.write(b'#version-connect katcp-protocol 5.0-IM\n')
+        self.writer.write(b'#version-connect katcp-protocol 5.1-IMB\n')
         await self.client.wait_connected()
         # Make sure that wait_connected works when already connected
         await self.client.wait_connected()
@@ -297,7 +297,7 @@ async def test_connect(server, client_queue, event_loop) -> None:
     (reader, writer) = await client_queue.get()
     await asyncio.sleep(1)
     assert not client_task.done()
-    writer.write(b'#version-connect katcp-protocol 5.0-IM\n')
+    writer.write(b'#version-connect katcp-protocol 5.1-IMB\n')
     client = await client_task
     assert client.is_connected
     client.close()
@@ -739,7 +739,7 @@ class TestClientNoReconnect:
 
 class TestClientNoMidSupport:
     async def test_single(self, channel, event_loop) -> None:
-        channel.writer.write(b'#version-connect katcp-protocol 5.0-M\n')
+        channel.writer.write(b'#version-connect katcp-protocol 5.1-M\n')
         await channel.client.wait_connected()
         future = event_loop.create_task(channel.client.request('echo'))
         assert await channel.reader.readline() == b'?echo\n'
@@ -749,7 +749,7 @@ class TestClientNoMidSupport:
         assert result == ([], [Message.inform('echo', b'an inform')])
 
     async def test_concurrent(self, channel, event_loop) -> None:
-        channel.writer.write(b'#version-connect katcp-protocol 5.0-M\n')
+        channel.writer.write(b'#version-connect katcp-protocol 5.1-M\n')
         await channel.client.wait_connected()
         future1 = event_loop.create_task(channel.client.request('echo', 1))
         future2 = event_loop.create_task(channel.client.request('echo', 2))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -199,7 +199,7 @@ async def get_version_info(reader: asyncio.StreamReader,
     await check_reply(
         reader,
         [
-            prefix + b' katcp-protocol 5.0-MI\n',
+            prefix + b' katcp-protocol 5.1-MIB\n',
             prefix + ' katcp-library aiokatcp-{} aiokatcp-{}\n'.format(
                 aiokatcp.minor_version(), aiokatcp.__version__).encode('ascii'),
             prefix + b' katcp-device dummy-1.0 dummy-build-1.0.0\n'
@@ -728,6 +728,50 @@ async def test_sensor_sampling_auto_override(
         b'#sensor-status 123456792.0 1 auto-override nominal 1\n',
         b'#sensor-status 123456792.0 1 auto-override nominal 1\n',
         b'!watchdog ok\n'])
+
+
+async def test_sensor_sampling_bulk(
+        mock_time, server: DummyServer,
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    writer.write(b'?sensor-sampling float-sensor,counter-queries event\n')
+    await check_reply(reader, [
+        b'#sensor-status 123456789.0 1 float-sensor unknown 0.0\n',
+        b'#sensor-status 123456789.0 1 counter-queries nominal 0\n',
+        b'!sensor-sampling ok float-sensor,counter-queries event\n'])
+    # Check that the strategy has been set
+    writer.write(b'?sensor-sampling float-sensor\n')
+    writer.write(b'?sensor-sampling counter-queries\n')
+    await check_reply(reader, [
+        b'!sensor-sampling ok float-sensor event\n',
+        b'!sensor-sampling ok counter-queries event\n'
+    ])
+
+
+async def test_sensor_sampling_bulk_missing_sensor(
+        server: DummyServer,
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    writer.write(b'?sensor-sampling float-sensor,missing event\n')
+    await check_reply(reader, [
+        rb"!sensor-sampling fail Unknown\_sensor\_'missing'" + b'\n'])
+    # Check that the strategy has not been set on the first sensor
+    writer.write(b'?sensor-sampling float-sensor\n')
+    await check_reply(reader, [
+        b'!sensor-sampling ok float-sensor none\n'
+    ])
+
+
+async def test_sensor_sampling_bulk_invalid_strategy(
+        server: DummyServer,
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    writer.write(b'?sensor-sampling float-sensor,foo differential 1\n')
+    await check_reply(reader, [
+        rb'!sensor-sampling fail differential\_strategies\_only\_valid\_for\_integer'
+        rb'\_and\_float\_sensors' + b'\n'])
+    # Check that the strategy has not been set on the first sensor
+    writer.write(b'?sensor-sampling float-sensor\n')
+    await check_reply(reader, [
+        b'!sensor-sampling ok float-sensor none\n'
+    ])
 
 
 @pytest.mark.server_cls.with_args(BadServer)


### PR DESCRIPTION
Increments server version to katcp 5.1 and adds the "B" flag for bulk
sensor sampling support. It does not update the client SensorWatcher to
use it.
