### PR TITLE
More type annotations

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -9,3 +9,4 @@ pytest-asyncio
 pytest-cov
 pytest-mock
 types-decorator
+typing-extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,6 +78,7 @@ types-decorator==5.1.4
     # via -r requirements.in
 typing-extensions==4.1.1
     # via
+    #   -r requirements.in
     #   async-timeout
     #   importlib-metadata
     #   mypy

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,11 @@ setup(
         'Topic :: Scientific/Engineering :: Astronomy'
     ],
     tests_require=tests_require,
-    install_requires=['decorator>=4.1', 'async-timeout'],
+    install_requires=[
+        'async-timeout',
+        'decorator>=4.1',
+        'typing-extensions'
+    ],
     setup_requires=['katversion'],
     extras_require={
         'test': tests_require,

--- a/src/aiokatcp/__init__.py
+++ b/src/aiokatcp/__init__.py
@@ -33,7 +33,7 @@ except ImportError:
     import time as _time
     __version__ = "0.0+unknown.{}".format(_time.strftime('%Y%m%d%H%M'))
 else:
-    __version__ = _katversion.get_version(__path__[0])   # type: ignore  # mypy issue 1422
+    __version__ = _katversion.get_version(__path__[0])
 # END VERSION CHECK
 
 from .client import (  # noqa: F401

--- a/src/aiokatcp/client.py
+++ b/src/aiokatcp/client.py
@@ -37,15 +37,26 @@ import time
 import warnings
 from collections import OrderedDict
 from typing import (
-    Any, Callable, Dict, Generator, Iterable, List, Optional, Sequence, Set,
-    Tuple, Type, Union
+    Any, Callable, Dict, Generator, Iterable, List, Optional, Protocol,
+    Sequence, Set, Tuple, Type, Union, cast
 )
 
 from . import connection, core, sensor
 from .connection import FailReply, InvalidReply
 
 logger = logging.getLogger(__name__)
-_InformHandler = Callable[['Client', core.Message], None]
+
+
+class _Handler(Protocol):
+    _aiokatcp_orig_handler: Callable[..., None]
+
+
+class _InformHandler(_Handler):
+    def __call__(self, _client: 'Client', _msg: core.Message) -> None: ...
+
+
+class _InformCallback(_Handler):
+    def __call__(self, _msg: core.Message) -> None: ...
 
 
 class _PendingRequest:
@@ -59,7 +70,7 @@ class _PendingRequest:
 class ClientMeta(type):
     @classmethod
     def _wrap_inform(mcs, name: str, value: Callable[..., None]) -> _InformHandler:
-        return connection.wrap_handler(name, value, 1)
+        return cast(_InformHandler, connection.wrap_handler(name, value, 1))
 
     def __new__(mcs, name, bases, namespace, **kwds):
         namespace.setdefault('_inform_handlers', {})
@@ -114,6 +125,9 @@ class Client(metaclass=ClientMeta):
         An exception object associated with the last connection attempt. It is
         always ``None`` if :attr:`is_connected` is True.
     """
+
+    _inform_handlers: Dict[str, _InformHandler]  # Initialised by metaclass
+
     def __init__(self, host: str, port: int, *,
                  auto_reconnect: bool = True,
                  limit: int = connection.DEFAULT_LIMIT,
@@ -136,7 +150,7 @@ class Client(metaclass=ClientMeta):
         self._connected_callbacks: List[Callable[[], None]] = []
         self._disconnected_callbacks: List[Callable[[], None]] = []
         self._failed_connect_callbacks: List[Callable[[Exception], None]] = []
-        self._inform_callbacks: Dict[str, List[Callable[[core.Message], None]]] = {}
+        self._inform_callbacks: Dict[str, List[_InformCallback]] = {}
         self._sensor_monitor: Optional[_SensorMonitor] = None
         self._mid_support = False
         # Used to serialize requests if the server does not support message IDs
@@ -192,7 +206,7 @@ class Client(metaclass=ClientMeta):
     def handle_inform(self, msg: core.Message) -> None:
         self.logger.debug('Received %s', bytes(msg))
         # TODO: provide dispatch mechanism for informs
-        handler = self._inform_handlers.get(               # type: ignore
+        handler = self._inform_handlers.get(
             msg.name, self.__class__.unhandled_inform)
         try:
             handler(self, msg)
@@ -293,14 +307,14 @@ class Client(metaclass=ClientMeta):
         on the arguments of the callback. Callbacks are called in the order
         registered, after any handlers defined by methods in the class.
         """
-        wrapper = connection.wrap_handler(name, callback, 0)
+        wrapper = cast(_InformCallback, connection.wrap_handler(name, callback, 0))
         self._inform_callbacks.setdefault(name, []).append(wrapper)
 
     def remove_inform_callback(self, name: str, callback: Callable[..., None]) -> None:
         """Remove a callback registered with :meth:`add_inform_callback`."""
         cbs = self._inform_callbacks.get(name, [])
         for i in range(len(cbs)):
-            if cbs[i]._aiokatcp_orig_handler == callback:     # type: ignore
+            if cbs[i]._aiokatcp_orig_handler == callback:
                 del cbs[i]
                 if not cbs:
                     del self._inform_callbacks[name]
@@ -699,7 +713,7 @@ class SensorWatcher(AbstractSensorWatcher):
                 # normalising names in some way doesn't guarantee that.
                 # Instead, we use arbitrary numbering.
                 enums = [(f'ENUM{i}', value) for i, value in enumerate(values)]
-                # Type checking disabled due to https://github.com/python/mypy/issues/4184
+                # Type checking disabled due to https://github.com/python/mypy/issues/5317
                 stype = enum.Enum('discrete', enums, type=DiscreteMixin)  # type: ignore
                 self._enum_cache[values] = stype
                 return stype

--- a/src/aiokatcp/client.py
+++ b/src/aiokatcp/client.py
@@ -37,9 +37,11 @@ import time
 import warnings
 from collections import OrderedDict
 from typing import (
-    Any, Callable, Dict, Generator, Iterable, List, Optional, Protocol,
-    Sequence, Set, Tuple, Type, Union, cast
+    Any, Callable, Dict, Generator, Iterable, List, Optional, Sequence, Set,
+    Tuple, Type, Union, cast
 )
+
+from typing_extensions import Protocol
 
 from . import connection, core, sensor
 from .connection import FailReply, InvalidReply

--- a/src/aiokatcp/core.py
+++ b/src/aiokatcp/core.py
@@ -32,8 +32,7 @@ import logging
 import numbers
 import re
 from typing import (
-    Any, Callable, Generic, List, Match, Optional, Tuple, Type, TypeVar,
-    Union
+    Any, Callable, Generic, List, Match, Optional, Tuple, Type, TypeVar, Union
 )
 
 _T = TypeVar('_T')
@@ -576,11 +575,10 @@ class Message:
     def __ne__(self, other):
         return not self == other
 
-    # Mutable, so not safely hashable.
-    # The type: ignore should be removed after
-    # https://github.com/python/mypy/issues/4266
-    # is fixed.
-    __hash__ = None      # type: ignore
+    # Mutable, so not safely hashable. Python automatically sets __hash__ to
+    # None when __eq__ is provided, so we don't need to do it explicitly, and
+    # mypy complains if we do (https://github.com/python/mypy/issues/4266).
+    # __hash__ = None
 
     def reply_ok(self) -> bool:
         """Return True if this is a reply and its first argument is 'ok'."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -724,7 +724,7 @@ class TestClientNoReconnect:
             await channel.client.wait_connected()
 
     async def test_connect_failed(self, server, client_queue, event_loop) -> None:
-        host, port = server.sockets[0].getsockname()[:2]    # type: ignore
+        host, port = server.sockets[0].getsockname()[:2]
         client_task = event_loop.create_task(
             DummyClient.connect(host, port, auto_reconnect=False))
         (reader, writer) = await client_queue.get()


### PR DESCRIPTION
Mostly removing obsolete type: ignore comments, but _InformHandlers was
changed to a Protocol so that it could capture the fact that inform
handlers have an _aiokatcp_orig_handler attribute, and a _InformCallback
Protocol was added for the same reason.