### PR TITLE
Add config file for readthedocs, update Sphinx

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,7 @@
+version: 2
+python:
+  version: 3.7
+  install:
+    - requirements: doc-requirements.txt
+    - method: pip
+      path: .

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,2 +1,2 @@
-sphinx==4.1.1
+sphinx==4.5.0
 -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ identify==2.4.12
     # via pre-commit
 idna==3.3
     # via requests
-importlib-metadata==4.2.0
+importlib-metadata==4.11.3
     # via
     #   pluggy
     #   pre-commit


### PR DESCRIPTION
Using a config file is recommended by readthedocs (over configuration on
the web UI).

Updating sphinx required also updating importlib-metadata - I'm not sure
how that missed being updated previously.
