### PR TITLE
Service tasks

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+.. rubric:: Development versoin
+
+- Add support for :doc:`server/service_tasks`.
+
 .. rubric:: Version 1.1.0
 
 - Increment server protocol version to 5.1.

--- a/doc/server.rst
+++ b/doc/server.rst
@@ -7,3 +7,4 @@ Writing a server
 
    server/tutorial
    server/logging
+   server/service_tasks

--- a/doc/server/service_tasks.rst
+++ b/doc/server/service_tasks.rst
@@ -1,0 +1,35 @@
+Service tasks
+=============
+
+It is common for a katcp device server to do more than passively respond to
+requests. This work might be encapsulated in an :class:`asyncio.Task`, which
+needs to be started up when the server starts and shut down when the server is
+stopped.
+
+It's possible to do this manually (and indeed this was the only option up to
+version 1.1). However, handling exceptions from these tasks is tricky, and
+aiokatcp provides some extra support for this. In :meth:`.DeviceServer.start`
+you can create the task and pass it to :meth:`.DeviceServer.add_service_task`.
+The server will then do the following:
+
+1. When the server is stopped, the task will be cancelled then awaited. This
+   happens after :meth:`.DeviceServer.on_stop`, so if you need to shut down
+   the task in some other way, you can do so there.
+
+2. If the task throws an exception, the server will immediately be halted. The
+   exception will be re-thrown from :meth:`.DeviceServer.stop` or
+   :meth:`.DeviceServer.join`. Note that a :exc:`asyncio.CancelledError` will
+   *not* be re-thrown.
+
+3. If the task exits without raising an exception, or by raising
+   :exc:`asyncio.CancelledError`, it is removed from the list of service
+   tasks. It can thus be used for tasks that don't need to run for the full
+   lifetime of the server, without causing the list of tasks to grow without
+   bound.
+
+The list of active service tasks can be retrieved from
+:attr:`.DeviceServer.service_tasks`.
+
+When using Python 3.8 or later, it is recommended to pass the `name`
+parameter to :func:`asyncio.create_task`. This will be used in a log message
+if the task raises an exception.

--- a/examples/example_server.py
+++ b/examples/example_server.py
@@ -53,6 +53,7 @@ class Server(aiokatcp.DeviceServer):
         self.sensors.add(sensor)
         sensor = aiokatcp.Sensor(Foo, 'foo', 'nonsense')
         self.sensors.add(sensor)
+        self.add_service_task(asyncio.create_task(self._service_task()))
 
     async def request_echo(self, ctx, *args: str) -> Tuple:
         """Return the arguments to the caller"""
@@ -60,7 +61,7 @@ class Server(aiokatcp.DeviceServer):
 
     async def request_sleep(self, ctx, time: float) -> None:
         """Sleep for some amount of time"""
-        await asyncio.sleep(time, loop=self.loop)
+        await asyncio.sleep(time)
 
     async def request_fail(self, ctx, arg: str) -> None:
         """Request that always returns a failure reply"""
@@ -73,6 +74,12 @@ class Server(aiokatcp.DeviceServer):
     async def request_counter(self, ctx) -> None:
         """Increment counter-queries"""
         self.sensors['counter-queries'].value += 1
+
+    async def _service_task(self) -> None:
+        """Example service task that just broadcasts to clients."""
+        while True:
+            await asyncio.sleep(10)
+            self.mass_inform('hello', 'Hi I am a service task')
 
 
 async def main():


### PR DESCRIPTION
Add support for having the server take over ownership of asyncio tasks, monitor them for exceptions and cancel them when the server is shut down.

There is some other refactoring that proved necessary - refer to log messages of the individual commits for more details.