### PR TITLE
Properly clean up on server after client disconnects

### DIFF
--- a/src/aiokatcp/server.py
+++ b/src/aiokatcp/server.py
@@ -503,6 +503,7 @@ class DeviceServer(metaclass=DeviceServerMeta):
             self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         async def cleanup():
             await conn.wait_closed()
+            conn.close()
             self._connections.discard(conn)
         conn = ClientConnection(self, reader, writer)
         # Copy the connection list, to avoid mutation while iterating and to


### PR DESCRIPTION
The server-side handler loop for each client calls
`Connection.wait_closed` to wait for the client to disconnect, but that
does not clean up server-side resources (in particular, closing sensor
samplers). Add a call to `Connection.close` to allow that to happen.
