### PR TITLE
Replace None with '' for default sensor description

### DIFF
--- a/src/aiokatcp/sensor.py
+++ b/src/aiokatcp/sensor.py
@@ -115,7 +115,7 @@ class Sensor(Generic[_T]):
 
     def __init__(self, sensor_type: Type[_T],
                  name: str,
-                 description: str = None,
+                 description: str = '',
                  units: str = '',
                  default: _T = None,
                  initial_status: Status = Status.UNKNOWN,


### PR DESCRIPTION
If no description is given, this caused the ?sensor-list request to fail, because it doesn't know how to encode NoneType things.

Closes NGC-810.