### PR TITLE
Use weak references in AggregateSensor

### DIFF
--- a/src/aiokatcp/sensor.py
+++ b/src/aiokatcp/sensor.py
@@ -849,11 +849,10 @@ class AggregateSensor(Sensor[_T], metaclass=ABCMeta):
 
     def __del__(self):
         # Protect against an exception early in __init__
-        if getattr(self, "target", None) is not None:
-            for sensor in self.target.values():
-                # Could use filter_aggregate, but it might not work during
-                # destruction, and its a no-op if there is no attachment.
-                sensor.detach(self._update_aggregate_callback)
+        for sensor in getattr(self, "target", []).values():
+            # Could use filter_aggregate, but it might not work during
+            # destruction, and its a no-op if there is no attachment.
+            sensor.detach(self._update_aggregate_callback)
 
     @abstractmethod
     def update_aggregate(

--- a/src/aiokatcp/sensor.py
+++ b/src/aiokatcp/sensor.py
@@ -836,9 +836,9 @@ class AggregateSensor(Sensor[_T], metaclass=ABCMeta):
             if self.filter_aggregate(sensor):
                 sensor.attach(self._update_aggregate_callback)
                 # We don't use weakref.finalize to detach, because that
-                # finalizer will live until `self` is destroyed and thus keep,
-                # even `sensor` alive, even if `sensor` is removed from the
-                # sensor set and could otherwise be destroyed. Instead,
+                # finalizer would live until `self` is destroyed and thus
+                # keep that `sensor` alive, even if `sensor` is removed from
+                # the sensor set and could otherwise be destroyed. Instead,
                 # __del__ cleans up the attachments.
 
         self.target.add_add_callback(self._sensor_added)

--- a/src/aiokatcp/sensor.py
+++ b/src/aiokatcp/sensor.py
@@ -777,12 +777,13 @@ class _weak_callback:
             raise TypeError("name was not set for weak callback")
         cache = instance.__dict__
         weak_instance = weakref.ref(instance)
+        func = self._func
 
         @functools.wraps(self._func)
         def wrapper(*args, **kwargs):
             strong_instance = weak_instance()
             if strong_instance is not None:
-                return self._func(strong_instance, *args, **kwargs)
+                return func(strong_instance, *args, **kwargs)
 
         # Note: this overrides the descriptor, so that future accesses
         # will use the value directly.

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -37,7 +37,14 @@ from unittest.mock import create_autospec
 
 import pytest
 
-from aiokatcp.sensor import AggregateSensor, Reading, Sensor, SensorSampler, SensorSet
+from aiokatcp.sensor import (
+    AggregateSensor,
+    Reading,
+    Sensor,
+    SensorSampler,
+    SensorSet,
+    _weak_callback,
+)
 
 
 @pytest.mark.parametrize(
@@ -420,3 +427,11 @@ class TestAggregateSensor:
         for _ in range(5):
             gc.collect()
         assert weak() is None
+
+    def test_weak_callback_failures(self, agg_sensor, monkeypatch):
+        """Ensure code coverage of :class:`._weak_callback`."""
+        assert isinstance(MyAgg._sensor_added, _weak_callback)
+        wc = _weak_callback(lambda x: x)
+        monkeypatch.setattr(MyAgg, "bad_weak_callback", wc, raising=False)
+        with pytest.raises(TypeError):
+            agg_sensor.bad_weak_callback

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -409,7 +409,7 @@ class TestAggregateSensor:
         # "local variable '_my_agg' is assigned to but never used"
         # (we need to give it a name just to keep it alive)
         ss = SensorSet()
-        MyAgg(target=ss, sensor_type=int, name="agg")  # noqa: F841
+        my_agg = MyAgg(target=ss, sensor_type=int, name="agg")  # noqa: F841
         sensor = Sensor(int, "rubbish")
         ss.add(sensor)
         ss.remove(sensor)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -413,7 +413,7 @@ class TestAggregateSensor:
         # Don't use the fixtures, because they have mocks that might
         # record things and keep them alive.
         # The noqa is to suppress
-        # "local variable '_my_agg' is assigned to but never used"
+        # "local variable 'my_agg' is assigned to but never used"
         # (we need to give it a name just to keep it alive)
         ss = SensorSet()
         my_agg = MyAgg(target=ss, sensor_type=int, name="agg")  # noqa: F841


### PR DESCRIPTION
This ensures that an aggregate sensor can be garbage collected once it's no longer explicitly referenced, even if its target sensor set is still live. It also makes `__del__` more robust to exceptions occurring during `__init__`.