### PR TITLE
Simple aggregate sensor

### DIFF
--- a/src/aiokatcp/__init__.py
+++ b/src/aiokatcp/__init__.py
@@ -58,7 +58,14 @@ from .core import (  # noqa: F401
     get_type,
     register_type,
 )
-from .sensor import AggregateSensor, Reading, Sensor, SensorSampler, SensorSet  # noqa: F401
+from .sensor import (  # noqa: F401
+    AggregateSensor,
+    Reading,
+    Sensor,
+    SensorSampler,
+    SensorSet,
+    SimpleAggregateSensor,
+)
 from .server import DeviceServer, RequestContext  # noqa: F401
 
 

--- a/src/aiokatcp/sensor.py
+++ b/src/aiokatcp/sensor.py
@@ -970,7 +970,7 @@ class SimpleAggregateSensor(AggregateSensor[_T]):
         Returns
         -------
         bool
-            True if the removing the reading should result in a state update.
+            True if removing the reading should result in a state update.
         """
 
     @abstractmethod
@@ -992,9 +992,9 @@ class SimpleAggregateSensor(AggregateSensor[_T]):
         else:
             # Update the internal state
             update = False
-            if old_reading is not None and old_reading.status.valid_value():
+            if old_reading is not None:
                 update |= self.aggregate_remove(updated_sensor, old_reading)
-            if reading is not None and reading.status.valid_value():
+            if reading is not None:
                 update |= self.aggregate_add(updated_sensor, reading)
             if not update:
                 return None

--- a/src/aiokatcp/sensor.py
+++ b/src/aiokatcp/sensor.py
@@ -943,8 +943,7 @@ class SimpleAggregateSensor(AggregateSensor[_T]):
       which is updated by adding or removing readings.
 
     Subclasses must override :meth:`aggregate_add`, :meth:`aggregate_remove`,
-    :meth:`aggregate_value` and optionally :meth:`aggregate_status` and
-    :meth:`filter_aggregate`.
+    :meth:`aggregate_value` and optionally :meth:`filter_aggregate`.
 
     Currently, the timestamp will be set to the larger of the last sensor
     update time (using the sensor timestamp) and the last addition or removal
@@ -975,12 +974,8 @@ class SimpleAggregateSensor(AggregateSensor[_T]):
         """
 
     @abstractmethod
-    def aggregate_value(self) -> _T:
-        """Compute aggregate value from the internal state."""
-
-    def aggregate_status(self) -> Sensor.Status:
-        """Compute aggregate sensor state from the internal state."""
-        return Sensor.Status.NOMINAL
+    def aggregate_value(self) -> Tuple[_T, Sensor.Status]:
+        """Compute aggregate value and status from the internal state."""
 
     def update_aggregate(
         self,
@@ -1010,4 +1005,5 @@ class SimpleAggregateSensor(AggregateSensor[_T]):
             else:
                 timestamp = time.time()
         timestamp = max(timestamp, self.timestamp)  # Ensure time doesn't go backwards
-        return Reading(timestamp, self.aggregate_status(), self.aggregate_value())
+        value, status = self.aggregate_value()
+        return Reading(timestamp, status, value)

--- a/src/aiokatcp/sensor.py
+++ b/src/aiokatcp/sensor.py
@@ -943,7 +943,7 @@ class SimpleAggregateSensor(AggregateSensor[_T]):
       which is updated by adding or removing readings.
 
     Subclasses must override :meth:`aggregate_add`, :meth:`aggregate_remove`,
-    :meth:`aggregate_value` and optionally :meth:`filter_aggregate`.
+    :meth:`aggregate_compute` and optionally :meth:`filter_aggregate`.
 
     Currently, the timestamp will be set to the larger of the last sensor
     update time (using the sensor timestamp) and the last addition or removal
@@ -974,8 +974,8 @@ class SimpleAggregateSensor(AggregateSensor[_T]):
         """
 
     @abstractmethod
-    def aggregate_value(self) -> Tuple[_T, Sensor.Status]:
-        """Compute aggregate value and status from the internal state."""
+    def aggregate_compute(self) -> Tuple[Sensor.Status, _T]:
+        """Compute aggregate status and value from the internal state."""
 
     def update_aggregate(
         self,
@@ -1005,5 +1005,5 @@ class SimpleAggregateSensor(AggregateSensor[_T]):
             else:
                 timestamp = time.time()
         timestamp = max(timestamp, self.timestamp)  # Ensure time doesn't go backwards
-        value, status = self.aggregate_value()
+        status, value = self.aggregate_compute()
         return Reading(timestamp, status, value)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -467,10 +467,7 @@ class MySimpleAgg(SimpleAggregateSensor[int]):
         return False
 
     def aggregate_value(self):
-        return self._total
-
-    def aggregate_status(self):
-        return Sensor.Status.NOMINAL if self._total <= 10 else Sensor.Status.WARN
+        return (self._total, Sensor.Status.NOMINAL if self._total <= 10 else Sensor.Status.WARN)
 
 
 class TestSimpleAggregateSensor:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -466,8 +466,8 @@ class MySimpleAgg(SimpleAggregateSensor[int]):
             return True
         return False
 
-    def aggregate_value(self):
-        return (self._total, Sensor.Status.NOMINAL if self._total <= 10 else Sensor.Status.WARN)
+    def aggregate_compute(self):
+        return (Sensor.Status.NOMINAL if self._total <= 10 else Sensor.Status.WARN, self._total)
 
 
 class TestSimpleAggregateSensor:


### PR DESCRIPTION
Add a simplified base class for aggregate sensors. Instead of needing to handle additions, removals and updates all in one method, the model is a bag of readings to which the implementation adds or removes readings, then asks for the aggregate value. Timestamping is handled for the user with a fixed algorithm.