### PR TITLE
Use asyncio.run in example programs

### DIFF
--- a/examples/example_client.py
+++ b/examples/example_client.py
@@ -35,6 +35,8 @@ import aiokatcp
 
 
 async def main():
+    logging.basicConfig(level=logging.INFO)
+    asyncio.get_event_loop().add_signal_handler(signal.SIGINT, asyncio.current_task().cancel)
     client = await aiokatcp.Client.connect("localhost", 4444)
     async with client:
         while True:
@@ -45,13 +47,7 @@ async def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
-    loop = asyncio.get_event_loop()
-    loop.set_debug(True)
-    main_task = loop.create_task(main())
-    loop.add_signal_handler(signal.SIGINT, main_task.cancel)
     try:
-        loop.run_until_complete(main_task)
+        asyncio.run(main(), debug=True)
     except asyncio.CancelledError:
         pass
-    loop.close()

--- a/examples/example_server.py
+++ b/examples/example_server.py
@@ -128,6 +128,7 @@ class Server(aiokatcp.DeviceServer):
 
 
 async def main():
+    logging.basicConfig(level=logging.INFO)
     server = Server("localhost", 4444)
     handler = Server.LogHandler(server)
     logging.getLogger().addHandler(handler)
@@ -137,8 +138,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
-    loop = asyncio.get_event_loop()
-    loop.set_debug(True)
-    loop.run_until_complete(main())
-    loop.close()
+    asyncio.run(main(), debug=True)


### PR DESCRIPTION
It was added in Python 3.7, which is now the minimum version of asyncio,
so should be safe. This fixes some deprecation warnings that were being
shown related to `get_event_loop` implicitly creating the event loop,
and also ensures a cleaner shutdown.
