### PR TITLE
Support Optional on handler annotations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.942'
+    rev: 'v0.990'
     hooks:
       - id: mypy
         # Passing filenames to mypy can do odd things. See

--- a/src/aiokatcp/client.py
+++ b/src/aiokatcp/client.py
@@ -152,7 +152,7 @@ class Client(metaclass=ClientMeta):
         *,
         auto_reconnect: bool = True,
         limit: int = connection.DEFAULT_LIMIT,
-        loop: asyncio.AbstractEventLoop = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
     ) -> None:
         if loop is None:
             loop = asyncio.get_event_loop()
@@ -506,7 +506,7 @@ class Client(metaclass=ClientMeta):
         *,
         auto_reconnect: bool = True,
         limit: int = connection.DEFAULT_LIMIT,
-        loop: asyncio.AbstractEventLoop = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
     ) -> "Client":
         """Factory function that creates a client and waits until it is connected.
 

--- a/src/aiokatcp/client.py
+++ b/src/aiokatcp/client.py
@@ -261,7 +261,9 @@ class Client(metaclass=ClientMeta):
     def _warn_failed_connect(self, exc: Exception) -> None:
         self.logger.warning("Failed to connect to %s:%s: %s", self.host, self.port, exc)
 
-    def inform_version_connect(self, api: str, version: str, build_state: str = None) -> None:
+    def inform_version_connect(
+        self, api: str, version: str, build_state: Optional[str] = None
+    ) -> None:
         if api == "katcp-protocol":
             match = re.match(r"^(\d+)\.(\d+)(?:-(.+))?$", version)
             error = None
@@ -388,7 +390,10 @@ class Client(metaclass=ClientMeta):
         except OSError as error:
             self._on_failed_connect(error)
             return False
-        writer = asyncio.StreamWriter(transport, protocol, reader, self.loop)
+        # Ignore due to https://github.com/python/typeshed/issues/9199
+        writer = asyncio.StreamWriter(
+            transport, protocol, reader, self.loop  # type: ignore[arg-type]
+        )
         conn = connection.Connection(self, reader, writer, False)
         self._set_connection(conn)
         # Process replies until connection closes. _on_connected is

--- a/src/aiokatcp/core.py
+++ b/src/aiokatcp/core.py
@@ -54,7 +54,7 @@ class Address:
     _IPV4_RE = re.compile(r"^(?P<host>[^:]+)(:(?P<port>\d+))?$")
     _IPV6_RE = re.compile(r"^\[(?P<host>[^]]+)\](:(?P<port>\d+))?$")
 
-    def __init__(self, host: _IPAddress, port: int = None) -> None:
+    def __init__(self, host: _IPAddress, port: Optional[int] = None) -> None:
         self._host = host
         self._port = port
 
@@ -203,7 +203,7 @@ def register_type(
     name: str,
     encode: Callable[[_T], bytes],
     decode: Callable[[Type[_T], bytes], _T],
-    default: Callable[[Type[_T]], _T] = None,
+    default: Optional[Callable[[Type[_T]], _T]] = None,
 ) -> None:
     """Register a type for encoding and decoding in messages.
 
@@ -413,7 +413,7 @@ def decode(cls: Any, value: bytes) -> Any:
 class KatcpSyntaxError(ValueError):
     """Raised by parsers when encountering a syntax error."""
 
-    def __init__(self, message: str, raw: bytes = None) -> None:
+    def __init__(self, message: str, raw: Optional[bytes] = None) -> None:
         super().__init__(message)
         self.raw = raw
 
@@ -461,7 +461,7 @@ class Message:
     FAIL = b"fail"
     INVALID = b"invalid"
 
-    def __init__(self, mtype: Type, name: str, *arguments: Any, mid: int = None) -> None:
+    def __init__(self, mtype: Type, name: str, *arguments: Any, mid: Optional[int] = None) -> None:
         self.mtype = mtype
         if not self._NAME_RE.match(name):
             raise ValueError(f"name {name} is invalid")
@@ -473,15 +473,15 @@ class Message:
         self.mid = mid
 
     @classmethod
-    def request(cls, name: str, *arguments: Any, mid: int = None) -> "Message":
+    def request(cls, name: str, *arguments: Any, mid: Optional[int] = None) -> "Message":
         return cls(cls.Type.REQUEST, name, *arguments, mid=mid)
 
     @classmethod
-    def reply(cls, name: str, *arguments: Any, mid: int = None) -> "Message":
+    def reply(cls, name: str, *arguments: Any, mid: Optional[int] = None) -> "Message":
         return cls(cls.Type.REPLY, name, *arguments, mid=mid)
 
     @classmethod
-    def inform(cls, name: str, *arguments: Any, mid: int = None) -> "Message":
+    def inform(cls, name: str, *arguments: Any, mid: Optional[int] = None) -> "Message":
         return cls(cls.Type.INFORM, name, *arguments, mid=mid)
 
     @classmethod

--- a/src/aiokatcp/sensor.py
+++ b/src/aiokatcp/sensor.py
@@ -157,7 +157,7 @@ class Sensor(Generic[_T]):
         name: str,
         description: str = "",
         units: str = "",
-        default: _T = None,
+        default: Optional[_T] = None,
         initial_status: Status = Status.UNKNOWN,
         *,
         status_func: Callable[[_T], Status] = _default_status_func,
@@ -196,7 +196,9 @@ class Sensor(Generic[_T]):
         for delta_observer in self._delta_observers:
             delta_observer(self, reading, old_reading=old_reading)
 
-    def set_value(self, value: _T, status: Status = None, timestamp: float = None) -> None:
+    def set_value(
+        self, value: _T, status: Optional[Status] = None, timestamp: Optional[float] = None
+    ) -> None:
         """Set the current value of the sensor.
 
         Parameters
@@ -316,7 +318,7 @@ class SensorSampler(Generic[_T], metaclass=abc.ABCMeta):
         loop: asyncio.AbstractEventLoop,
         difference: Optional[_T] = None,
         shortest: core.Timestamp = core.Timestamp(0),
-        longest: core.Timestamp = None,
+        longest: Optional[core.Timestamp] = None,
         *,
         always_update: bool = False,
         is_auto: bool = False,
@@ -703,7 +705,7 @@ class SensorSet(Mapping[str, Sensor]):
     def get(self, name: str, default: Union[Sensor, _T]) -> Union[Sensor, _T]:
         ...
 
-    def get(self, name: str, default: object = None) -> object:  # noqa: F811
+    def get(self, name: str, default: Optional[object] = None) -> object:  # noqa: F811
         return self._sensors.get(name, default)
 
     def __contains__(self, s: object) -> bool:
@@ -765,7 +767,7 @@ class _weak_callback:
     def __set_name__(self, owner: type, name: str) -> None:
         self._name = name
 
-    def __get__(self, instance: object, owner: type = None):
+    def __get__(self, instance: object, owner: Optional[type] = None):
         # __get__ is magic in Python: it makes this class a "descriptor".
         # Refer to the language guide for an explanation of what that means.
         # In short, when one calls `obj.method` where `method` was

--- a/src/aiokatcp/server.py
+++ b/src/aiokatcp/server.py
@@ -296,8 +296,8 @@ class DeviceServer(metaclass=DeviceServerMeta):
         *,
         limit: int = connection.DEFAULT_LIMIT,
         max_pending: int = 100,
-        max_backlog: int = None,
-        loop: asyncio.AbstractEventLoop = None,
+        max_backlog: Optional[int] = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
     ) -> None:
         super().__init__()
         if not self.VERSION:

--- a/src/aiokatcp/server.py
+++ b/src/aiokatcp/server.py
@@ -652,7 +652,7 @@ class DeviceServer(metaclass=DeviceServerMeta):
         for conn in list(self._connections):
             self._write_async_message(conn, msg)
 
-    async def request_help(self, ctx: RequestContext, name: str = None) -> None:
+    async def request_help(self, ctx: RequestContext, name: Optional[str] = None) -> None:
         """Return help on the available requests.
 
         Return a description of the available requests using a sequence of
@@ -809,7 +809,7 @@ class DeviceServer(metaclass=DeviceServerMeta):
             matched = [self.sensors[name]]
         return sorted(matched, key=lambda sensor: sensor.name)
 
-    async def request_sensor_list(self, ctx: RequestContext, name: str = None) -> int:
+    async def request_sensor_list(self, ctx: RequestContext, name: Optional[str] = None) -> int:
         r"""Request the list of sensors.
 
         The list of sensors is sent as a sequence of #sensor-list informs.
@@ -869,7 +869,7 @@ class DeviceServer(metaclass=DeviceServerMeta):
             ctx.inform(s.name, s.description, s.units, s.type_name, *s.params)
         return len(sensors)
 
-    async def request_sensor_value(self, ctx: RequestContext, name: str = None) -> None:
+    async def request_sensor_value(self, ctx: RequestContext, name: Optional[str] = None) -> None:
         """Request the value of a sensor or sensors.
 
         A list of sensor values as a sequence of #sensor-value informs.
@@ -927,7 +927,7 @@ class DeviceServer(metaclass=DeviceServerMeta):
         self,
         ctx: RequestContext,
         name: str,
-        strategy: sensor.SensorSampler.Strategy = None,
+        strategy: Optional[sensor.SensorSampler.Strategy] = None,
         *args: bytes,
     ) -> tuple:
         """Configure or query the way a sensor is sampled.
@@ -1092,7 +1092,7 @@ class DeviceServer(metaclass=DeviceServerMeta):
         ctx.informs((conn.address,) for conn in self._connections)
 
     async def request_log_level(
-        self, ctx: RequestContext, level: core.LogLevel = None
+        self, ctx: RequestContext, level: Optional[core.LogLevel] = None
     ) -> core.LogLevel:
         """Query or set the current logging level.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -327,9 +327,9 @@ class MyAgg(AggregateSensor):
         updated_sensor: Optional[Sensor],
         reading: Optional[Reading],
         old_reading: Optional[Reading],
-    ) -> Reading:
+    ) -> Optional[Reading]:
         """Return a known Reading."""
-        pass
+        return None
 
 
 @pytest.fixture


### PR DESCRIPTION
Previously an argument like `foo: str = None` could be used to indicate
an optional string argument, but using the more correct (in terms of
PEP 484, and enforced by the latest numpy) `foo: Optional[str] = None`
would crash because `decode` didn't handle the Union. Ignore None
branches in union types to support this.

The mypy upgrade also flagged up a few other issues which have been
fixed or worked around.