### PR TITLE
Add type annotation to fix mypy internal error

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+.. rubric:: Version 1.6.1
+
+- Workaround to prevent old versions of mypy (0.780) from throwing an internal
+  error.
+
 .. rubric:: Version 1.6.0
 
 - Add :class:`.DeviceStatus` enum for discrete device-status sensors.

--- a/src/aiokatcp/time_sync.py
+++ b/src/aiokatcp/time_sync.py
@@ -35,7 +35,7 @@ inside a container with no privileges required.
 """
 
 from enum import Enum
-from typing import Mapping
+from typing import Callable, Mapping
 
 from . import adjtimex
 from .sensor import Sensor
@@ -55,7 +55,7 @@ def _us_to_s(value):
     return 1e-6 * value
 
 
-_TRANSFORMS = {
+_TRANSFORMS: Mapping[str, Callable] = {
     "maxerror": _us_to_s,
     "esterror": _us_to_s,
     "state": ClockState,


### PR DESCRIPTION
Mypy version 0.780 was hitting an internal error. Adding a type annotation for _TRANSFORMS fixes that.