### PR TITLE
Restore non-Linux support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         args: [--fix=lf]
       - id: trailing-whitespace
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.11.5
     hooks:
       - id: isort
   - repo: https://github.com/psf/black

--- a/src/aiokatcp/__init__.py
+++ b/src/aiokatcp/__init__.py
@@ -70,8 +70,10 @@ from .sensor import (  # noqa: F401
     SimpleAggregateSensor,
 )
 from .server import DeviceServer, RequestContext  # noqa: F401
-if sys.platform == 'linux':
+
+if sys.platform == "linux":
     from .time_sync import ClockState, TimeSyncUpdater  # noqa: F401
+
 
 def minor_version():
     return ".".join(__version__.split(".")[:2])

--- a/src/aiokatcp/__init__.py
+++ b/src/aiokatcp/__init__.py
@@ -37,6 +37,8 @@ else:
     __version__ = _katversion.get_version(__path__[0])
 # END VERSION CHECK
 
+import sys
+
 from .client import (  # noqa: F401
     AbstractSensorWatcher,
     Client,
@@ -68,8 +70,8 @@ from .sensor import (  # noqa: F401
     SimpleAggregateSensor,
 )
 from .server import DeviceServer, RequestContext  # noqa: F401
-from .time_sync import ClockState, TimeSyncUpdater  # noqa: F401
-
+if sys.platform == 'linux':
+    from .time_sync import ClockState, TimeSyncUpdater  # noqa: F401
 
 def minor_version():
     return ".".join(__version__.split(".")[:2])


### PR DESCRIPTION
The time sync functionality is Linux-only, since it attempts to interact explicitly with a `libc6` library. On non-Linux systems, simply don't provide `ClockState` and `TimeSyncUpdater`.