### PR TITLE
Restore time_sync module on macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         include:
           - python-version: "3.10"
-            os: ubuntu-20.04
             coverage: "yes"
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,3 @@
 src/aiokatcp.egg-info
 *.pyc
 __pycache__
-
-# macOS detritus
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 src/aiokatcp.egg-info
 *.pyc
 __pycache__
+
+# macOS detritus
+.DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.990'
+    rev: 'v1.4.1'
     hooks:
       - id: mypy
         # Passing filenames to mypy can do odd things. See

--- a/src/aiokatcp/__init__.py
+++ b/src/aiokatcp/__init__.py
@@ -37,8 +37,6 @@ else:
     __version__ = _katversion.get_version(__path__[0])
 # END VERSION CHECK
 
-import sys
-
 from .client import (  # noqa: F401
     AbstractSensorWatcher,
     Client,
@@ -70,9 +68,7 @@ from .sensor import (  # noqa: F401
     SimpleAggregateSensor,
 )
 from .server import DeviceServer, RequestContext  # noqa: F401
-
-if sys.platform == "linux":
-    from .time_sync import ClockState, TimeSyncUpdater  # noqa: F401
+from .time_sync import ClockState, TimeSyncUpdater  # noqa: F401
 
 
 def minor_version():

--- a/src/aiokatcp/__init__.py
+++ b/src/aiokatcp/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2017, 2022 National Research Foundation (SARAO)
+# Copyright 2017, 2022, 2023 National Research Foundation (SARAO)
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/src/aiokatcp/adjtimex.py
+++ b/src/aiokatcp/adjtimex.py
@@ -1,4 +1,4 @@
-# Copyright 2022 National Research Foundation (SARAO)
+# Copyright 2022, 2023 National Research Foundation (SARAO)
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/src/aiokatcp/adjtimex.py
+++ b/src/aiokatcp/adjtimex.py
@@ -134,10 +134,11 @@ try:
 except OSError:
     adjtimex = _no_adjtimex
 else:
-    adjtimex = _libc.adjtimex
-    adjtimex.argtypes = [ctypes.POINTER(Timex)]  # type: ignore[attr-defined]
-    adjtimex.restype = ctypes.c_int  # type: ignore[attr-defined]
-    adjtimex.errcheck = _errcheck  # type: ignore[attr-defined]
+    _real_adjtimex = _libc.adjtimex
+    _real_adjtimex.argtypes = [ctypes.POINTER(Timex)]
+    _real_adjtimex.restype = ctypes.c_int
+    _real_adjtimex.errcheck = _errcheck
+    adjtimex = _real_adjtimex
 
 
 def get_adjtimex() -> Tuple[int, Timex]:

--- a/src/aiokatcp/adjtimex.py
+++ b/src/aiokatcp/adjtimex.py
@@ -175,6 +175,6 @@ def get_adjtimex() -> Tuple[int, Timex]:
         Clock information
     """
     timex = Timex()
-    timex.mode = 0
+    timex.modes = 0
     state = adjtimex(timex)
     return state, timex

--- a/src/aiokatcp/adjtimex.py
+++ b/src/aiokatcp/adjtimex.py
@@ -87,6 +87,8 @@ STA_RONLY = (
 
 
 class Timeval(ctypes.Structure):
+    """See https://man7.org/linux/man-pages/man3/adjtime.3.html."""
+
     _fields_ = [
         ("tv_sec", ctypes.c_long),
         ("tv_usec", ctypes.c_long),
@@ -94,6 +96,8 @@ class Timeval(ctypes.Structure):
 
 
 class Timex(ctypes.Structure):
+    """See https://man7.org/linux/man-pages/man2/adjtimex.2.html."""
+
     _fields_ = [
         ("modes", ctypes.c_int),
         ("offset", ctypes.c_long),

--- a/src/aiokatcp/time_sync.py
+++ b/src/aiokatcp/time_sync.py
@@ -1,4 +1,4 @@
-# Copyright 2022 National Research Foundation (SARAO)
+# Copyright 2022, 2023 National Research Foundation (SARAO)
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/src/aiokatcp/time_sync.py
+++ b/src/aiokatcp/time_sync.py
@@ -84,7 +84,13 @@ class TimeSyncUpdater:
 
     def update(self) -> None:
         """Update the sensors now."""
-        state, timex = adjtimex.get_adjtimex()
+        try:
+            state, timex = adjtimex.get_adjtimex()
+        except NotImplementedError:
+            for sensor in self.sensor_map.values():
+                sensor.set_value(sensor.value, Sensor.Status.INACTIVE)
+            return
+
         if timex.status & adjtimex.STA_NANO:
             scale = 1e-9
         else:

--- a/tests/test_time_sync.py
+++ b/tests/test_time_sync.py
@@ -27,12 +27,7 @@
 
 """Tests for :mod:`aiokatcp.time_sync` and (indirectly) :mod:`aiokatcp.adjtimex`."""
 
-import sys
-
 import pytest
-
-if sys.platform != "linux":
-    pytest.skip("skipping Linux-only tests based on adjtimex", allow_module_level=True)
 
 import aiokatcp.adjtimex
 from aiokatcp import Sensor, SensorSet

--- a/tests/test_time_sync.py
+++ b/tests/test_time_sync.py
@@ -67,17 +67,17 @@ def mock_adjtimex(mocker, request) -> None:
 
 
 _linux = pytest.mark.skipif(
-    not sys.platform.startswith("linux"),
+    sys.platform != "linux",
     reason="Check real adjtimex on Linux systems only",
 )
 _non_linux = pytest.mark.skipif(
-    sys.platform.startswith("linux"),
+    sys.platform == "linux",
     reason="Check unimplemented adjtimex on non-Linux systems only",
 )
 
 
 @pytest.mark.parametrize(
-    ("expected_status",),
+    "expected_status",
     [
         pytest.param(Sensor.Status.NOMINAL, marks=_linux),
         pytest.param(Sensor.Status.INACTIVE, marks=_non_linux),

--- a/tests/test_time_sync.py
+++ b/tests/test_time_sync.py
@@ -1,4 +1,4 @@
-# Copyright 2017, 2022 National Research Foundation (SARAO)
+# Copyright 2017, 2022, 2023 National Research Foundation (SARAO)
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
MacOS does not have the `adjtimex` system call. As a result we have stripped out the entire `time_sync` module on non-Linux platforms.

However, packages like katsdpcontroller need the `ClockState` enum without the rest. Instead of spreading the complications, restore the `time_sync` module with a fake `adjtimex` instead.

It returns the correct time but with artificially large errors in the absence of real values (and the status is always "OK").

[This was a leftover from the beginning of the year when I wanted to test katsdpcontroller on my laptop. Nearly forgot about it - it was lurking in my working copy for months 🙂 ]
