### PR TITLE
Make Reading a data class

### DIFF
--- a/src/aiokatcp/sensor.py
+++ b/src/aiokatcp/sensor.py
@@ -34,6 +34,7 @@ import time
 import warnings
 import weakref
 from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass
 from typing import (
     Any,
     Callable,
@@ -79,6 +80,7 @@ class ClassicObserver(Protocol[_T]):
 Observer = Union[ClassicObserver[_T], DeltaObserver[_T]]
 
 
+@dataclass
 class Reading(Generic[_T]):
     """Sensor reading
 
@@ -92,12 +94,11 @@ class Reading(Generic[_T]):
         Sensor value at `timestamp`
     """
 
+    # Once Python 3.10 is the minimum, pass 'slots' parameter to dataclass instead
     __slots__ = ("timestamp", "status", "value")
-
-    def __init__(self, timestamp: float, status: "Sensor.Status", value: _T) -> None:
-        self.timestamp = timestamp
-        self.status = status
-        self.value = value
+    timestamp: float
+    status: "Sensor.Status"
+    value: _T
 
 
 def _default_status_func(value) -> "Sensor.Status":

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -45,6 +45,7 @@ from aiokatcp import (
     InvalidReply,
     Message,
     ProtocolError,
+    Reading,
     Sensor,
     SensorWatcher,
     SyncState,
@@ -734,14 +735,10 @@ class TestSensorWatcher:
         watcher.sensor_updated("bar", b"42", Sensor.Status.ERROR, 1234567891.5)
         watcher.batch_stop()
         sensor = watcher.sensors["test_foo"]
-        assert sensor.value == 12.5
-        assert sensor.status == Sensor.Status.WARN
-        assert sensor.timestamp == 1234567890.0
+        assert sensor.reading == Reading(1234567890.0, Sensor.Status.WARN, 12.5)
         for name in ["test_bar1", "test_bar2"]:
             sensor = watcher.sensors[name]
-            assert sensor.value == 42
-            assert sensor.status == Sensor.Status.ERROR
-            assert sensor.timestamp == 1234567891.5
+            assert sensor.reading == Reading(1234567891.5, Sensor.Status.ERROR, 42)
 
     def test_sensor_updated_bad_value(self, watcher: DummySensorWatcher) -> None:
         self.test_sensor_added(watcher)


### PR DESCRIPTION
Amongst other advantages (such as repr), this makes it implement `__eq__`, allowing it to be compared in unit tests.

While a reading ought to typically be immutable, I didn't make it frozen since I don't want to break backwards compatibility for any code that does modify a reading.

See NGC-1063.