### PR TITLE
Update .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,9 @@
 version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"
 python:
-  version: 3.7
   install:
     - requirements: doc-requirements.txt
     - method: pip


### PR DESCRIPTION
Readthedocs now requires the build.os key to build anything.