### PR TITLE
Bump versions of dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-merge-conflict
       - id: check-shebang-scripts-are-executable
@@ -13,19 +13,19 @@ repos:
         args: [--fix=lf]
       - id: trailing-whitespace
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.5
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.9.1
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.1.0
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.4.1'
+    rev: 'v1.5.1'
     hooks:
       - id: mypy
         # Passing filenames to mypy can do odd things. See
@@ -35,9 +35,8 @@ repos:
         # The pre-commit hook passes some options, but we set options in mypy.ini.
         args: []
         additional_dependencies: [
-          'async-timeout==4.0.2',
-          'pytest==7.1.1',
-          'types-decorator==5.1.4',
-          'types-setuptools==57.4.12',
-          'typing-extensions==4.1.1'
+          'async-timeout==4.0.3',
+          'pytest==7.4.2',
+          'types-decorator==5.1.1',
+          'typing-extensions==4.7.1'
         ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,13 +6,13 @@
 #
 async-solipsism==0.5
     # via -r requirements.in
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via -r requirements.in
 certifi==2023.7.22
     # via requests
 cfgv==3.3.1
     # via pre-commit
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via requests
 coverage[toml]==6.5.0
     # via
@@ -22,50 +22,69 @@ coveralls==3.3.1
     # via -r requirements.in
 decorator==5.1.1
     # via -r requirements.in
-distlib==0.3.6
+distlib==0.3.7
     # via virtualenv
 docopt==0.6.2
     # via coveralls
-filelock==3.12.0
+exceptiongroup==1.1.3
+    # via pytest
+filelock==3.12.2
     # via virtualenv
 identify==2.5.24
     # via pre-commit
 idna==3.4
     # via requests
+importlib-metadata==6.7.0
+    # via
+    #   pluggy
+    #   pre-commit
+    #   pytest
+    #   virtualenv
 iniconfig==2.0.0
     # via pytest
 nodeenv==1.8.0
     # via pre-commit
 packaging==23.1
     # via pytest
-platformdirs==3.5.1
+platformdirs==3.10.0
     # via virtualenv
-pluggy==1.0.0
+pluggy==1.2.0
     # via pytest
 pre-commit==2.21.0
     # via -r requirements.in
-pytest==7.3.1
+pytest==7.4.2
     # via
     #   -r requirements.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-mock
-pytest-asyncio==0.21.0
+pytest-asyncio==0.21.1
     # via -r requirements.in
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements.in
-pytest-mock==3.10.0
+pytest-mock==3.11.1
     # via -r requirements.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via pre-commit
 requests==2.31.0
     # via coveralls
-typing-extensions==4.6.0
-    # via -r requirements.in
-urllib3==2.0.2
+tomli==2.0.1
+    # via
+    #   coverage
+    #   pytest
+typing-extensions==4.7.1
+    # via
+    #   -r requirements.in
+    #   async-timeout
+    #   importlib-metadata
+    #   platformdirs
+    #   pytest-asyncio
+urllib3==2.0.4
     # via requests
-virtualenv==20.23.0
+virtualenv==20.24.5
     # via pre-commit
+zipp==3.15.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
types-setuptools was removed from the mypy config: it was only present for pkg_resources, which is no longer used.