### PR TITLE
Update CI to latest actions/checkout and setup-python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,18 +15,11 @@ jobs:
           - python-version: "3.10"
             coverage: "yes"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-cache-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-cache-${{ matrix.python-version }}-
-            ${{ runner.os }}-pip-cache-
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true  # TODO remove once Python 3.12 is released
+          cache: pip
       - run: pip install -U pip setuptools wheel
       - run: pip install -r requirements.txt
       - run: pip install --no-deps -e .


### PR DESCRIPTION
Also remove the manual actions/cache in favour of the caching support in setup-python.