### PR TITLE
Fix unit tests on Python 3.13

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -244,6 +244,7 @@ async def get_version_info(
 @pytest.fixture
 def mock_time(mocker, event_loop) -> None:
     mocker.patch("time.time", lambda: event_loop.time() + 123456789.0)
+    mocker.patch("time.time_ns", lambda: event_loop.time() * 1e9 + 123456789e9)
 
 
 async def test_start_twice(server: DummyServer) -> None:


### PR DESCRIPTION
Python 3.13 uses time.time_ns() to get timestamps for logging, so extend the mock of time.time() to also mock time.time.ns().