### PR TITLE
Add random seed fixture to tests for reproducibility

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import random
+import pytest
+
+@pytest.fixture(autouse=True)
+def set_random_seed():
+    random.seed(42)
+    yield


### PR DESCRIPTION
## Description
This PR adds a simple fixture to `tests/conftest.py` that sets a fixed seed for the `random` module across all tests. The change ensures that random values generated during testing—like the sleep wait time in `src/aiokatcp/client.py` (line 420)—are consistent between runs.

In `client.py`, the line:
```python
wait = (random.random() * 1.0) * 0.5 * backoff
```

uses `random.random()` to determine sleep duration, which could introduce flakiness in tests depending on timing or scheduling. While setting a seed won't eliminate all potential flakiness (e.g., race conditions or external factors), it does make test behavior more predictable and reproducible, which can be a big help for debugging.

### Current Issues (Before this PR):

The tests currently use random without setting a fixed seed, which causes several problems :

a. Flaky Tests: Tests sometimes pass and sometimes fail due to different random values;
b. Hard to Reproduce: When a test fails, it's difficult to reproduce the exact conditions;
c. Inconsistent CI/CD: Different CI runs may have different outcomes;
d. Time Wasted: Developers spend time debugging issues that are hard to replicate.

(Im not saying these problems are happening, but they can happen.)

### Solution

Set a global random seed right after imports in the test file.

### Benefits

a. Reproducibility: All test runs will use the same random values;
b. Easier Debugging: When a test fails, we can easily reproduce the issue;
c. Consistent CI/CD: Every CI run will have the same behavior;
d. Clear Intent: It's immediately obvious that we're using controlled randomness;
e. Time Saved: Less time spent on debugging non-deterministic test failures.