### PR TITLE
Add filtering capability to SensorWatcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 src/aiokatcp.egg-info
 *.pyc
 __pycache__
+.hypothesis

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.9.0'
+    rev: 'v1.14.1'
     hooks:
       - id: mypy
         # Passing filenames to mypy can do odd things. See
@@ -38,6 +38,7 @@ repos:
         args: []
         additional_dependencies: [
           'async-timeout==4.0.3',
+          'hypothesis==6.113.0',
           'katcp-codec==0.1.0',
           'pytest==8.1.1',
           'types-decorator==5.1.1',

--- a/doc/client/sensor_watcher.rst
+++ b/doc/client/sensor_watcher.rst
@@ -10,9 +10,11 @@ mirroring its sensors) and pushing sensor values into another monitoring
 system.
 
 To facilitate these use cases, it is possible to add one or more sensor
-watchers to a client, using :meth:`~.Client.add_sensor_watcher`.
-Whenever a client has at least one sensor watcher, it will automatically stay
-subscribed to all sensors.
+watchers to a client, using :meth:`~.Client.add_sensor_watcher`. Sensor
+watchers can be freely added and removed, but once a sensor watcher has been
+added to a client (even if it is later removed), one should not manually
+subscribe to any sensors as this will conflict with the automatic subscription
+logic.
 
 The sensor watcher must be an instance of :class:`~.AbstractSensorWatcher`.
 This is a low-level base class which should be subclassed to implement callbacks.
@@ -28,6 +30,11 @@ via the :meth:`~.AbstractSensorWatcher.state_updated` callback, which takes a
 
 One can also use :attr:`~.SensorWatcher.synced` (an :class:`asyncio.Event`) to
 determine the sync status and to wait for sync to be achieved.
+
+By default, a watcher will receive updates for all sensors of the server.
+However, one can override :meth:`~.AbstractSensorWatcher.filter` to select
+only sensors of interest. Doing so can improve efficiency, since the client
+will only subscribe to sensors that are of interest to at least one watcher.
 
 There is an example of using a :class:`~.SensorWatcher` to proxy the sensors of
 one another in :file:`examples/mirror_sensors.py` in the aiokatcp source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ katcpcmd = "aiokatcp.tools.katcpcmd:main"
 [project.optional-dependencies]
 test = [
     "async-solipsism>=0.6",
+    "hypothesis",
     "pytest",
     "pytest-asyncio>=0.23",
     "pytest-mock",

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 async-solipsism
 async-timeout
 decorator
+hypothesis
 katcp-codec
 pre-commit
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ async-solipsism==0.7
     # via -r requirements.in
 async-timeout==5.0.1
     # via -r requirements.in
+attrs==25.3.0
+    # via hypothesis
 cfgv==3.4.0
     # via pre-commit
 coverage[toml]==7.6.1
@@ -17,9 +19,13 @@ decorator==5.1.1
 distlib==0.3.9
     # via virtualenv
 exceptiongroup==1.2.2
-    # via pytest
+    # via
+    #   hypothesis
+    #   pytest
 filelock==3.16.1
     # via virtualenv
+hypothesis==6.113.0
+    # via -r requirements.in
 identify==2.6.1
     # via pre-commit
 iniconfig==2.0.0
@@ -50,6 +56,8 @@ pytest-mock==3.14.0
     # via -r requirements.in
 pyyaml==6.0.2
     # via pre-commit
+sortedcontainers==2.4.0
+    # via hypothesis
 tomli==2.2.1
     # via
     #   coverage

--- a/src/aiokatcp/client.py
+++ b/src/aiokatcp/client.py
@@ -418,7 +418,7 @@ class Client(metaclass=ClientMeta):
                     # Exponential backoff if connections are failing
                     backoff = min(backoff * 2.0, 60.0)
                 # Pick a random value in [0.5 * backoff, backoff]
-                wait = (random.random() * 1.0) * 0.5 * backoff
+                wait = (random.random() + 1.0) * 0.5 * backoff
                 await asyncio.sleep(wait)
         else:
             await self._run_once()

--- a/src/aiokatcp/client.py
+++ b/src/aiokatcp/client.py
@@ -993,6 +993,8 @@ class _SensorMonitor:
             self._connected()
 
     def add_watcher(self, watcher: AbstractSensorWatcher) -> None:
+        if watcher in self._watchers:
+            return
         self._watchers[watcher] = None
         # Populate the watcher with already-known information
         if self._state != SyncState.DISCONNECTED:

--- a/src/aiokatcp/client.py
+++ b/src/aiokatcp/client.py
@@ -974,7 +974,8 @@ class _SensorMonitor:
         self._state = SyncState.DISCONNECTED
         # Task that continuously synchronises
         self._update_task = asyncio.create_task(self._update())
-        # Event used to wake up _update_task (via _trigger_update)
+        # Event used to wake up _update_task (via _trigger_update). This must
+        # always be consistent with _state (set iff _State is SYNCING)
         self._update_event = asyncio.Event()
         # Sensors we have seen, indexed by name
         self._sensors: Dict[str, _MonitoredSensor] = {}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -776,14 +776,14 @@ class TestSensorWatcher:
         assert sensor.name == "test_foo"
         assert sensor.description == "A sensor"
         assert sensor.units == "F"
-        assert sensor.stype == float
+        assert sensor.stype is float
         assert sensor.status == Sensor.Status.UNKNOWN
         for name in ["test_bar1", "test_bar2"]:
             sensor = watcher.sensors[name]
             assert sensor.name == name
             assert sensor.description == "A duplicated sensor"
             assert sensor.units == "s"
-            assert sensor.stype == int
+            assert sensor.stype is int
             assert sensor.status == Sensor.Status.UNKNOWN
 
     def test_sensor_added_discrete(self, watcher: DummySensorWatcher) -> None:


### PR DESCRIPTION
The API change is the addition of AbstractSensorWatcher.filter, which allows a sensor watcher to subscribe to only a subset of sensors, with the underlying connection subscribed only to those sensors needed by at least one watcher. However, the underlying implementation has been essentially rewritten, and _SensorMonitor should probably be reviewed from scratch rather than looking at diffs. The old implementation was always somewhat buggy if one tried to add or remove watchers after the connection was established, and the reliance on cancellation to restart synchronisation if there was a change during sync was problematic (it was impossible to know whether a sensor was subscribed if you cancel the `?sensor-sampling` request).

The new approach has a continuously-running task that will keep trying to synchronise, and when it achieves synchronisation it will go to sleep until woken up again. The class documents a number of invariants that are preserved to avoid race conditions.

Rather than testing the filtering by adding more tests to the current test suite, I've added in hypothesis, which uses randomised tests to experiment with many ways the system state could evolve over time.

There are still a few warts due to NGC-1529, which can cause the state machine to consider is_connected to be true (and hence the state to be SYNCING/SYNCED rather than DISCONNECTED) even when the connection has been shut down. However, there seem to be enough workarounds for now to keep all the tests happy.

One change in functionality is that previously, removing the last watcher would cause the _SensorMonitor to be shut down. That would be nice to do, since it means no longer issuing `?sensor-list` in response to `#interface-changed` informs. However, trying to get the logic right to close down the sensor monitor correctly was too nasty, particularly because it can only truly be done asynchronously (because we have to unsubscribe from sensors and wait for the responses) which then gets interesting if a new watcher is added before that completes.

I recommend reviewing this as a single unit rather than commit-at-a-time, since there are several rewrites in the history.