### PR TITLE
Speed up "decoding" to `bytes` type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - run: pip check
       - run: pytest -Werror --cov=aiokatcp --cov-branch
       - run: pre-commit run --all-files
-      - uses: coverallsapp/github-action@v2.3.3
+      - uses: coverallsapp/github-action@v2.3.6
         with:
           parallel: true
           flag-name: ${{ matrix.os }}
@@ -40,6 +40,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Finalise Coveralls
-        uses: coverallsapp/github-action@v2.3.3
+        uses: coverallsapp/github-action@v2.3.6
         with:
           parallel-finished: true


### PR DESCRIPTION
This decoding is a no-op, but previously it was done by using `bytes()` as an identity function on bytes objects. It is (you get the same object back), but it's much faster to actually use an identity function.